### PR TITLE
fix: auto-pull busybox image for pause containers in podman

### DIFF
--- a/crates/kubelet/src/runtime.rs
+++ b/crates/kubelet/src/runtime.rs
@@ -1307,6 +1307,12 @@ impl ContainerRuntime {
             raw_hostname.to_string()
         };
 
+        // Ensure busybox image is available (critical for podman which may not auto-pull)
+        // Use IfNotPresent policy to avoid unnecessary pulls on every pod start
+        self.ensure_image("busybox:latest", Some("IfNotPresent"))
+            .await
+            .context("Failed to ensure busybox image for pause container")?;
+
         let config = Config {
             image: Some("busybox:latest".to_string()),
             cmd: Some(vec!["sleep".to_string(), "infinity".to_string()]),


### PR DESCRIPTION
Fixes #4

## Changes

This PR adds automatic pulling of the busybox:latest image before creating pause containers. This ensures pods can start successfully in podman environments where the busybox image may not be pre-cached.

## Implementation

- Added `ensure_image("busybox:latest", Some("IfNotPresent"))` call in `start_pause_container()` before creating the pause container config
- Uses IfNotPresent policy to avoid unnecessary pulls when the image is already available
- Properly propagates errors with context

## Testing

Tested on:
- macOS with podman-machine (Podman 5.8.0)
- Fresh podman VM without pre-cached busybox
- Verified pods now start successfully without manual `podman pull busybox`

## Impact

This change has minimal performance impact:
- Image check uses in-memory cache first (fast path)
- Only pulls busybox on first pod creation
- Subsequent pod creations skip the pull (IfNotPresent policy)