### PR TITLE
fix: use podman/docker detection in bootstrap-cluster.sh

### DIFF
--- a/scripts/bootstrap-cluster.sh
+++ b/scripts/bootstrap-cluster.sh
@@ -34,6 +34,15 @@ print_success() {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# Detect container runtime (podman or docker)
+if command -v podman &> /dev/null; then
+    CONTAINER_CMD="podman"
+elif command -v docker &> /dev/null; then
+    CONTAINER_CMD="docker"
+else
+    CONTAINER_CMD="docker" # Default to docker for compatibility
+fi
+
 # Check if kubectl is available
 KUBECTL=""
 if [ -f "$PROJECT_ROOT/target/release/kubectl" ]; then
@@ -82,9 +91,9 @@ fi
 # Step 3: Delete existing CoreDNS resources to ensure fresh creation with proper service account token
 print_step "Cleaning up existing CoreDNS resources (if any)..."
 # Remove CoreDNS container
-docker rm -f $(docker ps -a --filter "name=coredns" --format "{{.ID}}") 2>/dev/null && echo "  Deleted CoreDNS container" || echo "  No CoreDNS container to delete"
+$CONTAINER_CMD rm -f $($CONTAINER_CMD ps -a --filter "name=coredns" --format "{{.ID}}") 2>/dev/null && echo "  Deleted CoreDNS container" || echo "  No CoreDNS container to delete"
 # Remove CoreDNS pod from etcd
-docker exec rusternetes-etcd etcdctl del /registry/pods/kube-system/coredns 2>/dev/null && echo "  Deleted CoreDNS pod from etcd" || echo "  No CoreDNS pod in etcd"
+$CONTAINER_CMD exec rusternetes-etcd etcdctl del /registry/pods/kube-system/coredns 2>/dev/null && echo "  Deleted CoreDNS pod from etcd" || echo "  No CoreDNS pod in etcd"
 
 # Step 4: Apply bootstrap cluster resources
 print_step "Applying bootstrap resources (namespaces, services, CoreDNS)..."


### PR DESCRIPTION
Fixes #8

## Changes

This PR adds automatic container runtime detection to `scripts/bootstrap-cluster.sh`, allowing the script to work with both podman and docker environments.

## Implementation

- Added `CONTAINER_CMD` variable at the start of the script
- Detects podman first (if available), falls back to docker
- Replaced hardcoded `docker` commands with `$CONTAINER_CMD` variable
- No functional changes to the script logic

## Modified Commands

The following commands now use `$CONTAINER_CMD`:
- `docker rm -f $(docker ps ...)` → `$CONTAINER_CMD rm -f $($CONTAINER_CMD ps ...)`
- `docker exec rusternetes-etcd ...` → `$CONTAINER_CMD exec rusternetes-etcd ...`

## Testing

Tested on:
- macOS with podman-machine (Podman 5.8.0, no docker)
- Verified bootstrap completes successfully
- CoreDNS cleanup works correctly
- etcd operations succeed

## Backward Compatibility

Fully backward compatible:
- Docker users: script detects docker and uses it (no change in behavior)
- Podman users: script now works correctly
- Default fallback to docker if neither is detected (matches original behavior)

## Impact

This is a low-risk change that only affects container runtime command selection. All other script logic remains unchanged.