### PR TITLE
fix: include container network IPs in TLS certificate SANs

### DIFF
--- a/scripts/generate-certs.sh
+++ b/scripts/generate-certs.sh
@@ -44,6 +44,28 @@ mkdir -p "$CERT_DIR"
 # Generate private key
 openssl ecparam -name prime256v1 -genkey -noout -out "$KEY_FILE"
 
+# Detect container runtime and get network subnet
+# Try podman first, then docker
+CONTAINER_RT=""
+NETWORK_SUBNET=""
+NETWORK_GATEWAY=""
+
+if command -v podman &>/dev/null && podman network inspect rusternetes-network &>/dev/null 2>&1; then
+    CONTAINER_RT="podman"
+    NETWORK_SUBNET=$(podman network inspect rusternetes-network 2>/dev/null | jq -r '.[0].subnets[0].subnet // empty')
+    NETWORK_GATEWAY=$(podman network inspect rusternetes-network 2>/dev/null | jq -r '.[0].subnets[0].gateway // empty')
+elif command -v docker &>/dev/null && docker network inspect rusternetes-network &>/dev/null 2>&1; then
+    CONTAINER_RT="docker"
+    NETWORK_SUBNET=$(docker network inspect rusternetes-network 2>/dev/null | jq -r '.[0].IPAM.Config[0].Subnet // empty')
+    NETWORK_GATEWAY=$(docker network inspect rusternetes-network 2>/dev/null | jq -r '.[0].IPAM.Config[0].Gateway // empty')
+fi
+
+# Extract base IP from gateway (e.g., 10.89.0.1 -> 10.89.0)
+BASE_IP=""
+if [ -n "$NETWORK_GATEWAY" ]; then
+    BASE_IP=$(echo "$NETWORK_GATEWAY" | sed 's/\.[0-9]*$//')
+fi
+
 # Create certificate configuration
 cat > "${CERT_DIR}/cert.conf" <<EOF
 [req]
@@ -73,6 +95,17 @@ DNS.7 = kubernetes.default.svc.cluster.local
 IP.1 = 127.0.0.1
 IP.2 = 10.96.0.1
 EOF
+
+# Add container network IPs to certificate SANs
+# Include gateway + first 10 IPs to cover typical pod IP assignments
+if [ -n "$BASE_IP" ]; then
+    echo "# Container network: $CONTAINER_RT ($NETWORK_SUBNET)" >> "${CERT_DIR}/cert.conf"
+    IP_INDEX=3
+    for i in {1..10}; do
+        echo "IP.$IP_INDEX = ${BASE_IP}.${i}" >> "${CERT_DIR}/cert.conf"
+        IP_INDEX=$((IP_INDEX + 1))
+    done
+fi
 
 # Generate self-signed certificate (valid for 10 years, matching the Rust implementation)
 openssl req -new -x509 \


### PR DESCRIPTION
Fixes #10

## Changes

Updates `scripts/generate-certs.sh` to dynamically detect the container network subnet and include those IPs in the API server TLS certificate SANs.

## Implementation

1. **Runtime Detection**: Checks for podman first, then docker
2. **Network Inspection**: Queries `rusternetes-network` for subnet and gateway
3. **Dynamic SAN Generation**: Includes gateway + first 10 IPs from the subnet
4. **Backward Compatible**: Works with both docker and podman setups

## Example Output

```bash
# Podman (10.89.0.0/24):
IP Address:10.89.0.1, IP Address:10.89.0.2, IP Address:10.89.0.3, ...

# Docker (172.18.0.0/16):
IP Address:172.18.0.1, IP Address:172.18.0.2, IP Address:172.18.0.3, ...
```

## Testing

Tested on:
- macOS with podman-machine (Podman 5.8.0)
- Verified certificate includes podman network IPs (10.89.0.1-10)
- Confirmed sonobuoy pod can now connect without TLS errors
- Regenerated certs on fresh install

## Before/After

**Before:**
```
tls: failed to verify certificate: x509: certificate is valid for
127.0.0.1, 10.96.0.1, 172.18.0.2, not 10.89.0.3
```

**After:**
```
Successfully connected from pod IP 10.89.0.3
```

## Impact

- **Low risk**: Only affects cert generation script
- **High value**: Enables conformance testing in podman environments
- **Required for**: In-cluster tools, service mesh, sonobuoy tests

## Notes

This fix specifically addresses the TLS certificate issue. There's a separate issue with KUBERNETES_SERVICE_HOST environment variables not being set by kubelet, which will be addressed in a follow-up PR.