### PR TITLE
fix: use ClusterIP for pod KUBERNETES_SERVICE_HOST

### DIFF
--- a/crates/kubelet/src/config.rs
+++ b/crates/kubelet/src/config.rs
@@ -298,27 +298,17 @@ impl RuntimeConfig {
             .or_else(|| std::env::var("CLUSTER_SERVICE_CIDR").ok())
             .unwrap_or_else(|| "10.96.0.0/12".to_string());
 
-        // Allow overriding the kubernetes service host via env var.
-        // In Docker Desktop environments, the ClusterIP (10.96.0.1) is not
-        // routable from bridge containers because kube-proxy's iptables DNAT
-        // only applies in the host network namespace. Use the API server's
-        // Use the kubernetes service ClusterIP (10.96.0.1) as KUBERNETES_SERVICE_HOST.
-        // This is stable across container restarts (unlike container IPs which change).
-        // The TLS cert includes 10.96.0.1 as a SAN.
-        // Fallback to the override hostname if set.
-        let kubernetes_service_host = if let Ok(override_host) =
-            std::env::var("KUBERNETES_SERVICE_HOST_OVERRIDE")
-        {
-            // Don't resolve to IP — use the hostname or ClusterIP directly.
-            // Container IPs change on restart; ClusterIP and DNS names are stable.
-            tracing::info!(
-                "Using KUBERNETES_SERVICE_HOST_OVERRIDE: {}",
-                override_host
-            );
-            override_host
-        } else {
-            first_ip_from_cidr(&cluster_service_cidr).unwrap_or_else(|_| "10.96.0.1".to_string())
-        };
+        // Pods should ALWAYS use the kubernetes service ClusterIP (10.96.0.1) for
+        // KUBERNETES_SERVICE_HOST, as kube-proxy will correctly route this to the
+        // API server. The ClusterIP is stable across restarts and works in all
+        // networking configurations.
+        //
+        // Note: KUBERNETES_SERVICE_HOST_OVERRIDE is for the kubelet itself to
+        // connect to the API server (useful in some container environments where
+        // ClusterIP routing doesn't work from the kubelet container), but it
+        // should NOT affect pod environment variables.
+        let kubernetes_service_host =
+            first_ip_from_cidr(&cluster_service_cidr).unwrap_or_else(|_| "10.96.0.1".to_string());
 
         let config = Self {
             root_dir: PathBuf::from(root_dir),


### PR DESCRIPTION
## Summary

Fixes #13 - Pods now correctly receive `KUBERNETES_SERVICE_HOST=10.96.0.1` (the kubernetes service ClusterIP) instead of the pod's own network IP.

## Changes

- Removed `KUBERNETES_SERVICE_HOST_OVERRIDE` logic from pod environment variable configuration in `crates/kubelet/src/config.rs`
- Added comment clarifying that the override is for kubelet-to-API-server communication only
- Ensures pods always use the stable ClusterIP which kube-proxy routes correctly

## Why

The `KUBERNETES_SERVICE_HOST_OVERRIDE` environment variable was being applied to both the kubelet itself AND the pod environment variables it generates. This caused pods in podman environments to receive their own network IP (e.g., `10.89.0.3`) instead of the ClusterIP (`10.96.0.1`), breaking API server connectivity.

## Test Plan

- [x] Code builds successfully
- [x] Kubelet container image builds with changes
- [ ] Conformance tests pass with pods correctly connecting to API server at ClusterIP

## Testing Notes

Tested in podman environment on macOS where this bug was originally discovered. Pods should now be able to connect to the API server using the stable ClusterIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)