### PR TITLE
ci: add Rust tests workflow (build + nextest + clippy)

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -13,6 +13,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Clone rhino adjacent to repo
+        # `cargo fmt --all` loads workspace metadata, which fails if the
+        # optional `rhino` path dep (`../../../rhino` from crates/storage)
+        # is missing on disk. The default `sqlite` feature on the
+        # rusternetes binary activates it, so rhino has to exist.
+        run: git clone --depth 1 https://github.com/calfonso/rhino.git ../rhino
+
       - name: Install Rust toolchain
         run: |
           rustup update --no-self-update stable
@@ -20,4 +27,13 @@ jobs:
           rustup default stable
 
       - name: Validate formatting
-        run: cargo fmt --all -- --check
+        # `cargo fmt --all` recurses into path-deps (rhino) too, but the
+        # rhino repo has its own rustfmt config and isn't owned by this
+        # project. Format only the workspace members enumerated by
+        # `cargo metadata --no-deps`.
+        run: |
+          PKGS=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[].name' \
+            | sed 's/^/-p /' \
+            | tr '\n' ' ')
+          cargo fmt $PKGS -- --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,80 @@
+name: Rust tests
+
+on:
+  # Run once per change: push events only fire for main (post-merge
+  # validation); feature-branch pushes that have an open PR fire via
+  # the pull_request `synchronize` event instead. Without the branch
+  # filter every PR update would trigger two duplicate runs.
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  build-and-test:
+    name: cargo nextest + clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Clone rhino adjacent to repo
+        # crates/storage/Cargo.toml resolves the optional `rhino` dep via
+        # `path = "../../../rhino"`, i.e. as a sibling of $GITHUB_WORKSPACE.
+        # The default `sqlite` feature on the rusternetes binary activates
+        # this dep, so `cargo metadata` (and therefore every cargo step
+        # below) fails unless rhino is present on disk.
+        run: git clone --depth 1 https://github.com/calfonso/rhino.git ../rhino
+
+      - name: Install Rust toolchain
+        run: |
+          rustup update --no-self-update stable
+          rustup component add --toolchain stable clippy
+          rustup default stable
+
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Install cargo-nextest
+        # Prebuilt binary install — much faster and more parallel than
+        # `cargo test`. The action caches the binary across runs.
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
+      - name: Cache cargo registry + target
+        # Rust-aware cache: prunes stale artifacts, hashes Cargo.lock plus
+        # rustc version, and shares hits across feature branches. Much
+        # higher hit rate than the plain actions/cache it replaces.
+        uses: Swatinem/rust-cache@v2
+        with:
+          # Bump if you want to invalidate cache without changing deps.
+          prefix-key: "v1-rust"
+
+      - name: cargo nextest run (compile + test in one pass)
+        # nextest compiles test binaries and runs them in parallel; reuses
+        # cargo's incremental compilation cache so this is the only Rust
+        # build step needed. --no-fail-fast surfaces all failures per run.
+        # Doctests are not run (nextest limitation) — none of the
+        # workspace currently depends on doctest coverage; add a separate
+        # `cargo test --doc` step if that changes.
+        run: cargo nextest run --workspace --locked --no-fail-fast
+
+      - name: cargo clippy (informational, all targets)
+        # Warnings are surfaced in the run log but do not fail CI yet —
+        # the baseline has 30+ pre-existing warnings (deprecated rand
+        # APIs, unused methods etc.). Ratchet to `-- -D warnings` after
+        # that backlog is cleaned up. Default features only: the
+        # optional `jaeger` feature pulls in opentelemetry-jaeger which
+        # is itself deprecated upstream.
+        #
+        # `--all-targets` also acts as the bin-target build check the
+        # old explicit `cargo build` step provided — clippy compiles
+        # every target before lint, so any compile error in a bin fails
+        # this step.
+        run: cargo clippy --workspace --all-targets --locked


### PR DESCRIPTION
## Goal

The existing `fmt.yml` only checks formatting. Add a parallel **Rust tests** workflow that proves every PR (a) builds the workspace, (b) passes the test suite via `cargo nextest`, and (c) surfaces clippy findings. Catches regressions before merge.

## Workflow design

- **Triggers:** push to `main` + every `pull_request`. The `branches: [main]` filter on push prevents duplicate runs when a feature-branch push also has an open PR (PR `synchronize` fires the same job).
- **protoc** installed via apt — `api-server/build.rs` needs it for the gnostic openapi proto.
- **rhino cloned adjacent** at `../rhino` because `crates/storage/Cargo.toml` resolves the optional rhino dep via `path = "../../../rhino"`. The default `sqlite` feature pulls it in, so it has to exist on disk for `cargo metadata` + build to work. The `fmt.yml` workflow needs the same treatment.
- **cargo-nextest** replaces `cargo test` (2-4× faster scheduling, better parallelism). Installed as a prebuilt binary via [`taiki-e/install-action`](https://github.com/taiki-e/install-action).
- **Swatinem/rust-cache@v2** instead of plain `actions/cache` — Rust-aware pruning + Cargo.lock + rustc hash for higher hit rates.
- **Clippy runs without `-D warnings`** while the baseline has ~30 pre-existing warnings (deprecated rand APIs after the 0.9 bump, unused-method warnings, const-is-empty etc.). Ratchet to deny mode once that backlog is cleaned up in a follow-up.
- **fmt.yml updated** to enumerate workspace members via `cargo metadata --no-deps | jq` rather than `cargo fmt --all`. `--all` recurses into rhino (a vendored sibling repo with its own rustfmt config) — we should only enforce style on our own crates.

## Dependency

PR #32 ("bring test suite to green baseline") should land first so the very first run of the new workflow shows green. Without it, 9 pre-existing test failures + the daemonset assertion drift will keep this red.

## Verification

Local on this branch (after merging #32):
```
cargo build --workspace --locked
cargo nextest run --workspace --locked --no-fail-fast
cargo clippy --workspace --all-targets --locked
```