### PR TITLE
fix(controllers): retry storage updates on conflict, log other errors

### DIFF
--- a/crates/controller-manager/src/controllers/apiservice.rs
+++ b/crates/controller-manager/src/controllers/apiservice.rs
@@ -444,7 +444,7 @@ impl<S: Storage + 'static> APIServiceAvailabilityController<S> {
                         }
                     }
                     if !found {
-                        arr.push(condition);
+                        arr.push(condition.clone());
                     }
                 }
             } else {
@@ -460,7 +460,50 @@ impl<S: Storage + 'static> APIServiceAvailabilityController<S> {
             "Updating APIService {} Available condition: {} ({})",
             apiservice_name, status, reason
         );
-        let _ = self.storage.update(&key, &apiservice).await;
+        match self.storage.update(&key, &apiservice).await {
+            Ok(_) => {}
+            Err(rusternetes_common::Error::Conflict(_)) => {
+                // Another writer raced — re-read and retry once.
+                if let Ok(mut fresh) = self.storage.get::<serde_json::Value>(&key).await {
+                    if let Some(status_obj) = fresh.get_mut("status") {
+                        if let Some(conditions) = status_obj
+                            .get_mut("conditions")
+                            .and_then(|v| v.as_array_mut())
+                        {
+                            let mut found = false;
+                            for c in conditions.iter_mut() {
+                                if c.get("type").and_then(|v| v.as_str()) == Some("Available") {
+                                    *c = condition.clone();
+                                    found = true;
+                                    break;
+                                }
+                            }
+                            if !found {
+                                conditions.push(condition);
+                            }
+                        } else {
+                            status_obj["conditions"] = serde_json::json!([condition]);
+                        }
+                    } else {
+                        fresh["status"] = serde_json::json!({ "conditions": [condition] });
+                    }
+                    if let Err(e) = self.storage.update(&key, &fresh).await {
+                        error!(
+                            error = %e,
+                            apiservice = apiservice_name,
+                            "failed to update apiservice after conflict retry"
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                error!(
+                    error = %e,
+                    apiservice = apiservice_name,
+                    "failed to update apiservice"
+                );
+            }
+        }
         Ok(())
     }
 }

--- a/crates/controller-manager/src/controllers/deployment.rs
+++ b/crates/controller-manager/src/controllers/deployment.rs
@@ -326,7 +326,15 @@ impl<S: Storage + 'static> DeploymentController<S> {
                     .get_or_insert_with(Vec::new)
                     .push(owner_ref);
                 let rs_key = build_key("replicasets", Some(namespace), &rs.metadata.name);
-                let _ = self.storage.update(&rs_key, &adopted).await;
+                if let Err(e) = self.storage.update(&rs_key, &adopted).await {
+                    if !matches!(e, rusternetes_common::Error::Conflict(_)) {
+                        error!(
+                            error = %e,
+                            replicaset = rs.metadata.name,
+                            "failed to adopt orphan ReplicaSet"
+                        );
+                    }
+                }
                 info!(
                     "Adopted orphan ReplicaSet {} into Deployment {}/{}",
                     rs.metadata.name, namespace, deployment.metadata.name
@@ -425,7 +433,15 @@ impl<S: Storage + 'static> DeploymentController<S> {
                                 revision_str.clone(),
                             );
                         let rs_key = build_key("replicasets", Some(namespace), &rs.metadata.name);
-                        let _ = self.storage.update(&rs_key, &updated_rs).await;
+                        if let Err(e) = self.storage.update(&rs_key, &updated_rs).await {
+                            if !matches!(e, rusternetes_common::Error::Conflict(_)) {
+                                error!(
+                                    error = %e,
+                                    replicaset = rs.metadata.name,
+                                    "failed to refresh ReplicaSet revision annotation"
+                                );
+                            }
+                        }
                     }
                 }
             }
@@ -449,7 +465,15 @@ impl<S: Storage + 'static> DeploymentController<S> {
                         revision_str,
                     );
                 let key = build_key("deployments", Some(namespace), &deployment.metadata.name);
-                let _ = self.storage.update(&key, &updated).await;
+                if let Err(e) = self.storage.update(&key, &updated).await {
+                    if !matches!(e, rusternetes_common::Error::Conflict(_)) {
+                        error!(
+                            error = %e,
+                            deployment = deployment.metadata.name,
+                            "failed to refresh deployment revision annotation"
+                        );
+                    }
+                }
             }
         }
 
@@ -714,21 +738,17 @@ impl<S: Storage + 'static> DeploymentController<S> {
                 //
                 // Count available replicas from all RSes (status-based, matching K8s).
                 // Fall back to counting pods directly if RS status is not yet populated.
-                let _all_available: i32 = owned_replicasets
-                    .iter()
-                    .map(|rs| {
-                        if let Some(status) = &rs.status {
-                            status.available_replicas
-                        } else {
-                            // Fall back to pod count
-                            tokio::task::block_in_place(|| {
-                                tokio::runtime::Handle::current().block_on(
-                                    self.count_available_pods_for_rs(&rs.metadata.name, namespace),
-                                )
-                            })
-                        }
-                    })
-                    .sum();
+                let mut all_available: i32 = 0;
+                for rs in &owned_replicasets {
+                    all_available += if let Some(status) = &rs.status {
+                        status.available_replicas
+                    } else {
+                        // Fall back to pod count
+                        self.count_available_pods_for_rs(&rs.metadata.name, namespace)
+                            .await
+                    };
+                }
+                let _all_available = all_available;
 
                 // New RS unavailable count = newRS.Spec.Replicas - newRS.Status.AvailableReplicas
                 let new_rs_available = if let Some(new_rs) = owned_replicasets
@@ -1232,11 +1252,14 @@ impl<S: Storage + 'static> DeploymentController<S> {
             );
         }
 
-        // Also update the deployment's revision annotation (with CAS retry)
+        // Also update the deployment's revision annotation (with CAS retry +
+        // exponential backoff + jitter so contended deployments don't thrash).
         {
+            use rand::Rng;
             let dep_key = build_key("deployments", Some(namespace), &deployment.metadata.name);
             let new_rev = new_revision.clone();
-            for _ in 0..3 {
+            let mut delay_ms: u64 = 10;
+            for attempt in 0..3 {
                 match self.storage.get::<Deployment>(&dep_key).await {
                     Ok(mut dep) => {
                         dep.metadata
@@ -1248,9 +1271,22 @@ impl<S: Storage + 'static> DeploymentController<S> {
                             );
                         match self.storage.update(&dep_key, &dep).await {
                             Ok(_) => break,
-                            Err(e) => {
-                                debug!("CAS retry updating deployment revision: {}", e);
+                            Err(rusternetes_common::Error::Conflict(_)) => {
+                                if attempt + 1 < 3 {
+                                    let jitter = rand::thread_rng().gen_range(0..delay_ms);
+                                    tokio::time::sleep(Duration::from_millis(delay_ms + jitter))
+                                        .await;
+                                    delay_ms = (delay_ms * 2).min(500);
+                                }
                                 continue;
+                            }
+                            Err(e) => {
+                                error!(
+                                    error = %e,
+                                    deployment = deployment.metadata.name,
+                                    "failed to update deployment revision annotation"
+                                );
+                                break;
                             }
                         }
                     }
@@ -1359,7 +1395,15 @@ impl<S: Storage + 'static> DeploymentController<S> {
                 changed = true;
             }
             if changed {
-                let _ = self.storage.update(&key, &fresh_rs).await;
+                if let Err(e) = self.storage.update(&key, &fresh_rs).await {
+                    if !matches!(e, rusternetes_common::Error::Conflict(_)) {
+                        error!(
+                            error = %e,
+                            replicaset = rs.metadata.name,
+                            "failed to refresh ReplicaSet replica annotations"
+                        );
+                    }
+                }
             }
         }
     }

--- a/crates/controller-manager/src/controllers/statefulset.rs
+++ b/crates/controller-manager/src/controllers/statefulset.rs
@@ -19,6 +19,35 @@ impl<S: Storage + 'static> StatefulSetController<S> {
         Self { storage }
     }
 
+    /// Re-read the pod, apply `mutate`, and write it back. On a resource-version
+    /// conflict, re-read and reapply once. NotFound is a no-op (the pod is
+    /// already gone). Other errors are logged via tracing::error!. Avoids
+    /// silently dropping storage failures from `let _ = storage.update(...)`.
+    async fn update_pod_with_retry<F>(&self, pod_key: &str, mutate: F)
+    where
+        F: Fn(&mut Pod) + Send,
+    {
+        for attempt in 0..2 {
+            let mut pod: Pod = match self.storage.get(pod_key).await {
+                Ok(p) => p,
+                Err(rusternetes_common::Error::NotFound(_)) => return,
+                Err(e) => {
+                    error!(error = %e, pod = pod_key, "failed to read pod for update");
+                    return;
+                }
+            };
+            mutate(&mut pod);
+            match self.storage.update(pod_key, &pod).await {
+                Ok(_) => return,
+                Err(rusternetes_common::Error::Conflict(_)) if attempt == 0 => continue,
+                Err(e) => {
+                    error!(error = %e, pod = pod_key, "failed to update pod");
+                    return;
+                }
+            }
+        }
+    }
+
     pub async fn run(self: Arc<Self>) -> Result<()> {
         info!("Starting StatefulSetController (watch-based)");
         let retry_interval = Duration::from_secs(5);
@@ -279,10 +308,11 @@ impl<S: Storage + 'static> StatefulSetController<S> {
             if is_terminal && pod.metadata.deletion_timestamp.is_none() {
                 // Delete the terminal pod so it gets recreated
                 let pod_key = build_key("pods", Some(namespace), &pod.metadata.name);
-                let mut pod_to_delete = pod.clone();
-                pod_to_delete.metadata.deletion_timestamp = Some(chrono::Utc::now());
-                pod_to_delete.metadata.deletion_grace_period_seconds = Some(0);
-                let _ = self.storage.update(&pod_key, &pod_to_delete).await;
+                self.update_pod_with_retry(&pod_key, |p| {
+                    p.metadata.deletion_timestamp = Some(chrono::Utc::now());
+                    p.metadata.deletion_grace_period_seconds = Some(0);
+                })
+                .await;
                 info!(
                     "StatefulSet {}/{}: deleted terminal pod {} (phase: {:?})",
                     namespace,
@@ -545,25 +575,30 @@ impl<S: Storage + 'static> StatefulSetController<S> {
                 // deletionTimestamp and lets the kubelet handle graceful shutdown.
                 let pod_key = build_key("pods", Some(namespace), &pod.metadata.name);
                 match self.storage.get::<Pod>(&pod_key).await {
-                    Ok(mut pod_to_delete) => {
+                    Ok(pod_to_delete) => {
                         if pod_to_delete.metadata.deletion_timestamp.is_none() {
-                            pod_to_delete.metadata.deletion_timestamp = Some(chrono::Utc::now());
-                            // Use pod's terminationGracePeriodSeconds (K8s default behavior
-                            // when DeleteOptions.GracePeriodSeconds is not set)
-                            pod_to_delete.metadata.deletion_grace_period_seconds = pod_to_delete
-                                .spec
-                                .as_ref()
-                                .and_then(|s| s.termination_grace_period_seconds);
-                            // Set pod phase to indicate it's terminating
-                            if let Some(ref mut status) = pod_to_delete.status {
-                                if !matches!(
-                                    status.phase,
-                                    Some(Phase::Succeeded) | Some(Phase::Failed)
-                                ) {
-                                    status.reason = Some("StatefulSetScaleDown".to_string());
+                            self.update_pod_with_retry(&pod_key, |p| {
+                                if p.metadata.deletion_timestamp.is_some() {
+                                    return;
                                 }
-                            }
-                            let _ = self.storage.update(&pod_key, &pod_to_delete).await;
+                                p.metadata.deletion_timestamp = Some(chrono::Utc::now());
+                                // Use pod's terminationGracePeriodSeconds (K8s default behavior
+                                // when DeleteOptions.GracePeriodSeconds is not set)
+                                p.metadata.deletion_grace_period_seconds = p
+                                    .spec
+                                    .as_ref()
+                                    .and_then(|s| s.termination_grace_period_seconds);
+                                // Set pod phase to indicate it's terminating
+                                if let Some(ref mut status) = p.status {
+                                    if !matches!(
+                                        status.phase,
+                                        Some(Phase::Succeeded) | Some(Phase::Failed)
+                                    ) {
+                                        status.reason = Some("StatefulSetScaleDown".to_string());
+                                    }
+                                }
+                            })
+                            .await;
                             info!(
                                 "Scale down: set deletionTimestamp on pod {} ({} -> {})",
                                 pod.metadata.name, current_replicas, desired_replicas
@@ -655,14 +690,18 @@ impl<S: Storage + 'static> StatefulSetController<S> {
                     if !pod_revision.is_empty() && (pod_is_ready || pod_is_active) {
                         let pod_key = format!("/registry/pods/{}/{}", namespace, pod.metadata.name);
                         if pod.metadata.deletion_timestamp.is_none() {
-                            let mut pod_to_delete = pod.clone();
-                            pod_to_delete.metadata.deletion_timestamp = Some(chrono::Utc::now());
-                            pod_to_delete.metadata.deletion_grace_period_seconds = pod_to_delete
-                                .spec
-                                .as_ref()
-                                .and_then(|s| s.termination_grace_period_seconds)
-                                .or(Some(30));
-                            let _ = self.storage.update(&pod_key, &pod_to_delete).await;
+                            self.update_pod_with_retry(&pod_key, |p| {
+                                if p.metadata.deletion_timestamp.is_some() {
+                                    return;
+                                }
+                                p.metadata.deletion_timestamp = Some(chrono::Utc::now());
+                                p.metadata.deletion_grace_period_seconds = p
+                                    .spec
+                                    .as_ref()
+                                    .and_then(|s| s.termination_grace_period_seconds)
+                                    .or(Some(30));
+                            })
+                            .await;
                             info!(
                                 "Rolling update: set deletionTimestamp on pod {} (old revision {}, update revision {})",
                                 pod.metadata.name, pod_revision, update_revision

--- a/crates/scheduler/src/scheduler.rs
+++ b/crates/scheduler/src/scheduler.rs
@@ -36,6 +36,35 @@ impl<S: Storage + Send + Sync + 'static> Scheduler<S> {
         }
     }
 
+    /// Write a pod update with one-attempt retry on resource-version Conflict
+    /// and tracing for all other errors. Avoids silently dropping storage
+    /// failures from `let _ = storage.update(...)`. The mutator is re-applied
+    /// to the freshly-read pod on Conflict, so it must be idempotent.
+    async fn update_pod_with_retry<F>(&self, pod_key: &str, mutate: F)
+    where
+        F: Fn(&mut Pod) + Send,
+    {
+        for attempt in 0..2 {
+            let mut pod: Pod = match self.storage.get(pod_key).await {
+                Ok(p) => p,
+                Err(rusternetes_common::Error::NotFound(_)) => return,
+                Err(e) => {
+                    error!(error = %e, pod = pod_key, "scheduler: failed to read pod");
+                    return;
+                }
+            };
+            mutate(&mut pod);
+            match self.storage.update(pod_key, &pod).await {
+                Ok(_) => return,
+                Err(rusternetes_common::Error::Conflict(_)) if attempt == 0 => continue,
+                Err(e) => {
+                    error!(error = %e, pod = pod_key, "scheduler: failed to update pod");
+                    return;
+                }
+            }
+        }
+    }
+
     pub async fn run(self: Arc<Self>) -> rusternetes_common::Result<()> {
         use futures::StreamExt;
 
@@ -202,7 +231,14 @@ impl<S: Storage + Send + Sync + 'static> Scheduler<S> {
                 if let Some(ref mut spec) = pod.spec {
                     spec.priority = Some(resolved);
                 }
-                let _ = self.storage.update(&pod_key, &pod).await;
+                self.update_pod_with_retry(&pod_key, |p| {
+                    if let Some(ref mut spec) = p.spec {
+                        if spec.priority.is_none() {
+                            spec.priority = Some(resolved);
+                        }
+                    }
+                })
+                .await;
             }
         }
 
@@ -321,12 +357,14 @@ impl<S: Storage + Send + Sync + 'static> Scheduler<S> {
                     let pod_ns = pod.metadata.namespace.as_deref().unwrap_or("default");
                     let pod_key =
                         rusternetes_storage::build_key("pods", Some(pod_ns), &pod.metadata.name);
-                    if let Ok(mut stored_pod) = self.storage.get::<Pod>(&pod_key).await {
-                        if let Some(ref mut spec) = stored_pod.spec {
-                            spec.priority = Some(resolved);
+                    self.update_pod_with_retry(&pod_key, |p| {
+                        if let Some(ref mut spec) = p.spec {
+                            if spec.priority.is_none() {
+                                spec.priority = Some(resolved);
+                            }
                         }
-                        let _ = self.storage.update(&pod_key, &stored_pod).await;
-                    }
+                    })
+                    .await;
                 }
             }
             // 5-second timeout per pod — if scheduling takes longer (e.g.,
@@ -413,12 +451,13 @@ impl<S: Storage + Send + Sync + 'static> Scheduler<S> {
                                 if let Err(e) = self.bind_pod_to_node(fresh_pod, &node_name).await {
                                     error!("Failed to bind preemptor to nominated node: {}", e);
                                     // Fall back to setting nominatedNodeName
-                                    if let Ok(mut p) = self.storage.get::<Pod>(&pod_key).await {
+                                    let nn = node_name.clone();
+                                    self.update_pod_with_retry(&pod_key, |p| {
                                         if let Some(ref mut status) = p.status {
-                                            status.nominated_node_name = Some(node_name.clone());
+                                            status.nominated_node_name = Some(nn.clone());
                                         }
-                                        let _ = self.storage.update(&pod_key, &p).await;
-                                    }
+                                    })
+                                    .await;
                                 } else {
                                     info!(
                                         "Immediately bound preemptor pod {} to node {}",
@@ -427,25 +466,27 @@ impl<S: Storage + Send + Sync + 'static> Scheduler<S> {
                                 }
                             } else {
                                 // Resources not yet free (victims still running) — set nominatedNodeName
-                                if let Ok(mut p) = self.storage.get::<Pod>(&pod_key).await {
+                                let nn = node_name.clone();
+                                self.update_pod_with_retry(&pod_key, |p| {
                                     if let Some(ref mut status) = p.status {
-                                        status.nominated_node_name = Some(node_name.clone());
+                                        status.nominated_node_name = Some(nn.clone());
                                     }
-                                    let _ = self.storage.update(&pod_key, &p).await;
-                                    info!(
-                                        "Set nominatedNodeName={} on preempting pod {} (resources not yet free)",
-                                        node_name, pod.metadata.name
-                                    );
-                                }
+                                })
+                                .await;
+                                info!(
+                                    "Set nominatedNodeName={} on preempting pod {} (resources not yet free)",
+                                    node_name, pod.metadata.name
+                                );
                             }
                         } else {
                             // Node not found — set nominatedNodeName anyway
-                            if let Ok(mut p) = self.storage.get::<Pod>(&pod_key).await {
+                            let nn = node_name.clone();
+                            self.update_pod_with_retry(&pod_key, |p| {
                                 if let Some(ref mut status) = p.status {
-                                    status.nominated_node_name = Some(node_name.clone());
+                                    status.nominated_node_name = Some(nn.clone());
                                 }
-                                let _ = self.storage.update(&pod_key, &p).await;
-                            }
+                            })
+                            .await;
                         }
                     }
 
@@ -464,12 +505,13 @@ impl<S: Storage + Send + Sync + 'static> Scheduler<S> {
                     );
                     let pod_key =
                         rusternetes_storage::build_key("pods", Some(pod_ns), &pod.metadata.name);
-                    if let Ok(mut p) = self.storage.get::<Pod>(&pod_key).await {
+                    let msg = sched_message.clone();
+                    self.update_pod_with_retry(&pod_key, |p| {
                         let condition = rusternetes_common::resources::PodCondition {
                             condition_type: "PodScheduled".to_string(),
                             status: "False".to_string(),
                             reason: Some("Unschedulable".to_string()),
-                            message: Some(sched_message.clone()),
+                            message: Some(msg.clone()),
                             last_transition_time: Some(chrono::Utc::now()),
                             observed_generation: None,
                         };
@@ -478,8 +520,8 @@ impl<S: Storage + Send + Sync + 'static> Scheduler<S> {
                             conditions.retain(|c| c.condition_type != "PodScheduled");
                             conditions.push(condition);
                         }
-                        let _ = self.storage.update(&pod_key, &p).await;
-                    }
+                    })
+                    .await;
 
                     // Emit FailedScheduling event — K8s conformance tests wait for this
                     let event_name = format!(


### PR DESCRIPTION
## Problem

Four controllers used \`let _ = self.storage.update(...).await\` to write status updates, silently swallowing every storage error. On a benign resource-version \`Conflict\` the update vanished — the controller's view of reality diverged from etcd. On a hard error nothing was logged, so failures were invisible.

## Fix

Each controller now matches \`Err\` explicitly:

- **apiservice**: \`update_condition\` writes the \`Available\` condition. On Conflict, re-read and re-apply once. Other errors log via \`tracing::error!\` with the apiservice name.
- **statefulset**: Three \`reconcile()\` sites set \`deletionTimestamp\` on pods (terminal-pod cleanup, scale-down, rolling update). Routed through a new private \`update_pod_with_retry()\` helper: re-read + reapply once on Conflict, no-op on NotFound, log other errors.
- **scheduler**: Six \`let _ = ...\` sites covering priority resolution, nominatedNodeName fallback after failed binding, and PodScheduled=Unschedulable condition writes. Same helper pattern.
- **deployment**: Three improvements bundled because they all hit \`reconcile_deployment\`:
  1. Drop \`tokio::task::block_in_place(|| Handle::current().block_on(...))\` from the available-replica fallback — the surrounding fn is already \`async\`. Replace with a sequential \`.await\` accumulator.
  2. Add exponential backoff with jitter (10ms → 500ms) to the deployment-revision CAS retry. Without jitter, contended deployments thrashed storage.
  3. Convert four silenced \`let _ = self.storage.update(...)\` sites (orphan-RS adoption, RS/deployment revision annotation refresh, RS replica annotations) to log non-Conflict errors via \`tracing::error!\`.

## Verification

\`cargo build --workspace --locked\` clean. Full test suite is green when stacked on #32; this PR adds no new test failures relative to the baseline.

## Dependency

Depends on #32 for the test suite to show green.