### PR TITLE
fix: remove panic paths from patch, ip_allocator, label_selector, cronjob

### DIFF
--- a/crates/api-server/src/ip_allocator.rs
+++ b/crates/api-server/src/ip_allocator.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::net::Ipv4Addr;
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard};
 
 /// Simple ClusterIP allocator for services
 /// Allocates IPs from a predefined CIDR range
@@ -14,6 +14,15 @@ pub struct ClusterIPAllocator {
 }
 
 impl ClusterIPAllocator {
+    /// Lock the allocated-IP set, recovering from poison rather than panicking.
+    /// A panic in another thread shouldn't lock out all future ClusterIP allocation.
+    fn lock_allocated(&self) -> MutexGuard<'_, HashSet<String>> {
+        self.allocated.lock().unwrap_or_else(|poisoned| {
+            tracing::warn!("ip_allocator mutex poisoned, recovering");
+            poisoned.into_inner()
+        })
+    }
+
     /// Create a new allocator with the default Kubernetes service CIDR
     /// 10.96.0.0/12 provides 1,048,576 IPs (10.96.0.0 - 10.111.255.255)
     pub fn new() -> Self {
@@ -40,7 +49,7 @@ impl ClusterIPAllocator {
     /// Allocate a new ClusterIP
     /// Returns None if all IPs are allocated
     pub fn allocate(&self) -> Option<String> {
-        let mut allocated = self.allocated.lock().unwrap();
+        let mut allocated = self.lock_allocated();
 
         // Try to find an available IP
         // Start from .1 (skip .0 which is network address)
@@ -59,7 +68,7 @@ impl ClusterIPAllocator {
 
     /// Allocate a specific IP if available
     pub fn allocate_specific(&self, ip: String) -> bool {
-        let mut allocated = self.allocated.lock().unwrap();
+        let mut allocated = self.lock_allocated();
 
         if allocated.contains(&ip) {
             return false;
@@ -76,7 +85,7 @@ impl ClusterIPAllocator {
 
     /// Release an allocated IP back to the pool
     pub fn release(&self, ip: &str) {
-        let mut allocated = self.allocated.lock().unwrap();
+        let mut allocated = self.lock_allocated();
         allocated.remove(ip);
     }
 
@@ -104,7 +113,7 @@ impl ClusterIPAllocator {
     #[allow(dead_code)]
     pub fn mark_allocated(&self, ip: String) {
         if self.is_in_range(&ip) {
-            let mut allocated = self.allocated.lock().unwrap();
+            let mut allocated = self.lock_allocated();
             allocated.insert(ip);
         }
     }
@@ -112,7 +121,7 @@ impl ClusterIPAllocator {
     /// Get statistics about IP allocation
     #[allow(dead_code)]
     pub fn stats(&self) -> (usize, u32) {
-        let allocated = self.allocated.lock().unwrap();
+        let allocated = self.lock_allocated();
         (allocated.len(), self.pool_size)
     }
 }

--- a/crates/api-server/src/patch.rs
+++ b/crates/api-server/src/patch.rs
@@ -924,6 +924,48 @@ mod tests {
         let result = apply_strategic_merge_patch(&original, &patch).unwrap();
         assert!(result["metadata"]["annotations"].is_null());
     }
+
+    #[test]
+    fn test_json_patch_add_missing_value_returns_err() {
+        let original = json!({"a": 1});
+        let patch = json!([{ "op": "add", "path": "/b" }]);
+        let result = apply_patch(&original, &patch, PatchType::JsonPatch);
+        match result {
+            Err(PatchError::InvalidPatch(msg)) => assert!(msg.contains("add")),
+            other => panic!(
+                "expected InvalidPatch for add without value, got {:?}",
+                other
+            ),
+        }
+    }
+
+    #[test]
+    fn test_json_patch_replace_missing_value_returns_err() {
+        let original = json!({"a": 1});
+        let patch = json!([{ "op": "replace", "path": "/a" }]);
+        let result = apply_patch(&original, &patch, PatchType::JsonPatch);
+        match result {
+            Err(PatchError::InvalidPatch(msg)) => assert!(msg.contains("replace")),
+            other => panic!(
+                "expected InvalidPatch for replace without value, got {:?}",
+                other
+            ),
+        }
+    }
+
+    #[test]
+    fn test_json_patch_test_missing_value_returns_err() {
+        let original = json!({"a": 1});
+        let patch = json!([{ "op": "test", "path": "/a" }]);
+        let result = apply_patch(&original, &patch, PatchType::JsonPatch);
+        match result {
+            Err(PatchError::InvalidPatch(msg)) => assert!(msg.contains("test")),
+            other => panic!(
+                "expected InvalidPatch for test without value, got {:?}",
+                other
+            ),
+        }
+    }
 }
 
 /// Recursively merge two JSON objects. For nested objects, entries from

--- a/crates/api-server/src/patch.rs
+++ b/crates/api-server/src/patch.rs
@@ -120,8 +120,12 @@ fn apply_merge_patch(original: &Value, patch: &Value) -> Result<Value, PatchErro
         json!({})
     };
 
-    let result_obj = result.as_object_mut().unwrap();
-    let patch_obj = patch.as_object().unwrap();
+    let result_obj = result
+        .as_object_mut()
+        .ok_or_else(|| PatchError::InvalidPatch("merge patch base is not an object".to_string()))?;
+    let patch_obj = patch
+        .as_object()
+        .ok_or_else(|| PatchError::InvalidPatch("merge patch is not an object".to_string()))?;
 
     for (key, value) in patch_obj {
         if value.is_null() {
@@ -156,10 +160,15 @@ fn apply_json_patch(original: &Value, patch: &Value) -> Result<Value, PatchError
 
 /// Apply a single JSON Patch operation
 fn apply_json_patch_operation(value: &Value, op: &JsonPatchOperation) -> Result<Value, PatchError> {
+    let require_value = |what: &str| -> Result<&Value, PatchError> {
+        op.value
+            .as_ref()
+            .ok_or_else(|| PatchError::InvalidPatch(format!("'value' required for {}", what)))
+    };
     match op.op {
-        JsonPatchOp::Add => add_operation(value, &op.path, op.value.as_ref().unwrap()),
+        JsonPatchOp::Add => add_operation(value, &op.path, require_value("add")?),
         JsonPatchOp::Remove => remove_operation(value, &op.path),
-        JsonPatchOp::Replace => replace_operation(value, &op.path, op.value.as_ref().unwrap()),
+        JsonPatchOp::Replace => replace_operation(value, &op.path, require_value("replace")?),
         JsonPatchOp::Move => {
             let from = op
                 .from
@@ -175,7 +184,7 @@ fn apply_json_patch_operation(value: &Value, op: &JsonPatchOperation) -> Result<
             copy_operation(value, from, &op.path)
         }
         JsonPatchOp::Test => {
-            test_operation(value, &op.path, op.value.as_ref().unwrap())?;
+            test_operation(value, &op.path, require_value("test")?)?;
             Ok(value.clone())
         }
     }
@@ -322,8 +331,12 @@ fn apply_strategic_merge_patch(original: &Value, patch: &Value) -> Result<Value,
         json!({})
     };
 
-    let result_obj = result.as_object_mut().unwrap();
-    let patch_obj = patch.as_object().unwrap();
+    let result_obj = result.as_object_mut().ok_or_else(|| {
+        PatchError::InvalidPatch("strategic merge base is not an object".to_string())
+    })?;
+    let patch_obj = patch.as_object().ok_or_else(|| {
+        PatchError::InvalidPatch("strategic merge patch is not an object".to_string())
+    })?;
 
     // Check for $patch directive
     let patch_strategy = patch_obj
@@ -404,15 +417,32 @@ fn apply_strategic_merge_patch(original: &Value, patch: &Value) -> Result<Value,
 
                     if let Some(to_delete) = delete_list {
                         // Remove specified values from the original array
-                        let mut original_array = result_obj[key].as_array().unwrap().clone();
+                        let mut original_array = result_obj[key]
+                            .as_array()
+                            .ok_or_else(|| {
+                                PatchError::InvalidPatch(format!(
+                                    "strategic merge: '{}' is not an array",
+                                    key
+                                ))
+                            })?
+                            .clone();
                         original_array.retain(|item| !to_delete.contains(item));
                         result_obj.insert(key.clone(), Value::Array(original_array));
                     } else {
                         // Strategic merge for arrays
-                        let merged_array = strategic_merge_arrays(
-                            result_obj[key].as_array().unwrap(),
-                            patch_value.as_array().unwrap(),
-                        )?;
+                        let orig_arr = result_obj[key].as_array().ok_or_else(|| {
+                            PatchError::InvalidPatch(format!(
+                                "strategic merge: '{}' is not an array",
+                                key
+                            ))
+                        })?;
+                        let patch_arr = patch_value.as_array().ok_or_else(|| {
+                            PatchError::InvalidPatch(format!(
+                                "strategic merge: patch for '{}' is not an array",
+                                key
+                            ))
+                        })?;
+                        let merged_array = strategic_merge_arrays(orig_arr, patch_arr)?;
                         result_obj.insert(key.clone(), Value::Array(merged_array));
                     }
                 } else if patch_value.is_object()
@@ -440,7 +470,7 @@ fn strategic_merge_arrays(original: &[Value], patch: &[Value]) -> Result<Vec<Val
     // Check if this is a named array (items have 'name' field)
     let is_named_array = patch
         .iter()
-        .all(|v| v.is_object() && v.as_object().unwrap().contains_key("name"));
+        .all(|v| v.as_object().is_some_and(|o| o.contains_key("name")));
 
     if is_named_array {
         // Merge by name
@@ -600,7 +630,9 @@ fn split_path(path: &str) -> Result<(&str, &str), PatchError> {
         ));
     }
 
-    let last_slash = path.rfind('/').unwrap();
+    let last_slash = path
+        .rfind('/')
+        .ok_or_else(|| PatchError::InvalidPatch(format!("Path missing '/': {}", path)))?;
     let parent = if last_slash == 0 {
         "/"
     } else {

--- a/crates/common/src/label_selector.rs
+++ b/crates/common/src/label_selector.rs
@@ -401,6 +401,19 @@ impl LabelRequirement {
     pub fn values(&self) -> Option<&[String]> {
         self.values.as_deref()
     }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_test(
+        key: impl Into<String>,
+        operator: LabelOperator,
+        values: Option<Vec<String>>,
+    ) -> Self {
+        Self {
+            key: key.into(),
+            operator,
+            values,
+        }
+    }
 }
 
 /// Label selector operators
@@ -448,23 +461,28 @@ impl fmt::Display for LabelSelector {
         let parts: Vec<String> = self
             .requirements
             .iter()
-            .map(|req| match req.operator {
-                LabelOperator::Equals => format!("{}={}", req.key, req.values.as_ref().unwrap()[0]),
-                LabelOperator::NotEquals => {
-                    format!("{}!={}", req.key, req.values.as_ref().unwrap()[0])
+            .map(|req| {
+                let first_value = || {
+                    req.values
+                        .as_ref()
+                        .and_then(|v| v.first())
+                        .map(String::as_str)
+                        .unwrap_or("")
+                };
+                let joined_values = || {
+                    req.values
+                        .as_ref()
+                        .map(|v| v.join(", "))
+                        .unwrap_or_default()
+                };
+                match req.operator {
+                    LabelOperator::Equals => format!("{}={}", req.key, first_value()),
+                    LabelOperator::NotEquals => format!("{}!={}", req.key, first_value()),
+                    LabelOperator::In => format!("{} in ({})", req.key, joined_values()),
+                    LabelOperator::NotIn => format!("{} notin ({})", req.key, joined_values()),
+                    LabelOperator::Exists => req.key.clone(),
+                    LabelOperator::DoesNotExist => format!("!{}", req.key),
                 }
-                LabelOperator::In => format!(
-                    "{} in ({})",
-                    req.key,
-                    req.values.as_ref().unwrap().join(", ")
-                ),
-                LabelOperator::NotIn => format!(
-                    "{} notin ({})",
-                    req.key,
-                    req.values.as_ref().unwrap().join(", ")
-                ),
-                LabelOperator::Exists => req.key.clone(),
-                LabelOperator::DoesNotExist => format!("!{}", req.key),
             })
             .collect();
         write!(f, "{}", parts.join(","))
@@ -475,6 +493,25 @@ impl fmt::Display for LabelSelector {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn test_display_does_not_panic_on_missing_values() {
+        // A LabelRequirement built without values (e.g. via a code path that
+        // bypasses the parser) used to panic in the Display impl. Now it
+        // renders as an empty value string.
+        for op in [
+            LabelOperator::Equals,
+            LabelOperator::NotEquals,
+            LabelOperator::In,
+            LabelOperator::NotIn,
+        ] {
+            let req = LabelRequirement::new_for_test("app", op, None);
+            let sel = LabelSelector {
+                requirements: vec![req],
+            };
+            let _ = format!("{}", sel); // must not panic
+        }
+    }
 
     #[test]
     fn test_parse_equality_simple() {

--- a/crates/controller-manager/src/controllers/cronjob.rs
+++ b/crates/controller-manager/src/controllers/cronjob.rs
@@ -464,8 +464,12 @@ impl<S: Storage + 'static> CronJobController<S> {
 
     async fn cleanup_old_jobs(&self, cronjob: &CronJob, namespace: &str) -> Result<()> {
         let cronjob_name = &cronjob.metadata.name;
-        let success_limit = cronjob.spec.successful_jobs_history_limit.unwrap_or(3);
-        let failed_limit = cronjob.spec.failed_jobs_history_limit.unwrap_or(1);
+        // Clamp negative user-supplied values to 0 so the cast to usize does not
+        // wrap to a huge number, which would prevent any history cleanup.
+        let success_limit: usize =
+            usize::try_from(cronjob.spec.successful_jobs_history_limit.unwrap_or(3)).unwrap_or(0);
+        let failed_limit: usize =
+            usize::try_from(cronjob.spec.failed_jobs_history_limit.unwrap_or(1)).unwrap_or(0);
 
         let job_prefix = format!("/registry/jobs/{}/", namespace);
         let mut all_jobs: Vec<Job> = self.storage.list(&job_prefix).await?;
@@ -526,8 +530,8 @@ impl<S: Storage + 'static> CronJobController<S> {
         });
 
         // Delete old successful jobs
-        if successful_jobs.len() > success_limit as usize {
-            let to_delete = successful_jobs.len() - success_limit as usize;
+        if successful_jobs.len() > success_limit {
+            let to_delete = successful_jobs.len() - success_limit;
             for job in successful_jobs.iter().take(to_delete) {
                 let job_name = &job.metadata.name;
                 let job_key = format!("/registry/jobs/{}/{}", namespace, job_name);
@@ -537,8 +541,8 @@ impl<S: Storage + 'static> CronJobController<S> {
         }
 
         // Delete old failed jobs
-        if failed_jobs.len() > failed_limit as usize {
-            let to_delete = failed_jobs.len() - failed_limit as usize;
+        if failed_jobs.len() > failed_limit {
+            let to_delete = failed_jobs.len() - failed_limit;
             for job in failed_jobs.iter().take(to_delete) {
                 let job_name = &job.metadata.name;
                 let job_key = format!("/registry/jobs/{}/{}", namespace, job_name);


### PR DESCRIPTION
## Problem

Five panic sites reachable from runtime inputs. Each is a process-killing failure for what should be a request-level error.

## Fix

- **\`crates/api-server/src/patch.rs\`**: ~13 production-code \`.unwrap()\` calls on JSON values — \`as_object_mut().unwrap()\`, \`op.value.as_ref().unwrap()\` for JSON-Patch Add/Replace/Test, array unwraps in strategic merge, \`path.rfind('/').unwrap()\` in split_path. Convert each to \`PatchError::InvalidPatch(...)\` via \`ok_or_else\`. Malformed PATCH bodies now return 400 instead of crashing the handler. **Includes regression tests** for JSON Patch missing-value panics.
- **\`crates/api-server/src/ip_allocator.rs\`**: 5 \`lock().unwrap()\` on \`std::sync::Mutex\`. A poison in any thread would lock out **all** future ClusterIP allocation. Route every caller through a \`lock_allocated()\` helper that recovers via \`PoisonError::into_inner()\` with a single warn-level log.
- **\`crates/common/src/label_selector.rs\`**: \`Display\` impl indexed \`req.values.as_ref().unwrap()[0]\` for Equals/NotEquals/In/NotIn. A hand-constructed \`LabelRequirement\` (one that bypassed the parser) would panic when formatted. Use safe accessors (\`.first()\`, \`.join()\`) with empty-string fallback. Adds a regression test.
- **\`crates/controller-manager/src/controllers/cronjob.rs\`**: \`successful_jobs_history_limit\` / \`failed_jobs_history_limit\` are \`i32\`. A negative value cast via \`as usize\` wraps to ~4 billion, which made the size comparison always pass and the subtraction also wrap, **preventing any history cleanup**. Use \`usize::try_from(...).unwrap_or(0)\` and drop the casts.

## Verification

\`cargo build --workspace --locked\` clean. New regression tests pass. No new test failures vs the baseline.

## Dependency

Depends on #32 for the test suite to show green.