### PR TITLE
fix(admission): log storage errors in quota check, fail-closed on resource list error

### DIFF
--- a/crates/api-server/src/admission.rs
+++ b/crates/api-server/src/admission.rs
@@ -1157,7 +1157,13 @@ pub async fn check_count_quota<S: Storage>(
     resource_type: &str,
 ) -> Result<(), rusternetes_common::Error> {
     let quota_prefix = format!("/registry/resourcequotas/{}/", namespace);
-    let quotas: Vec<ResourceQuota> = storage.list(&quota_prefix).await.unwrap_or_default();
+    let quotas: Vec<ResourceQuota> = match storage.list(&quota_prefix).await {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(error = %e, namespace, "failed to list resource quotas; skipping count quota check");
+            return Ok(());
+        }
+    };
 
     for quota in &quotas {
         if let Some(hard) = &quota.spec.hard {
@@ -1168,8 +1174,16 @@ pub async fn check_count_quota<S: Storage>(
                     let limit: i64 = limit_str.parse().unwrap_or(i64::MAX);
                     // Count current resources
                     let prefix = format!("/registry/{}/{}/", resource_type, namespace);
-                    let current: Vec<serde_json::Value> =
-                        storage.list(&prefix).await.unwrap_or_default();
+                    let current: Vec<serde_json::Value> = match storage.list(&prefix).await {
+                        Ok(v) => v,
+                        Err(e) => {
+                            warn!(error = %e, namespace, resource_type, "failed to list resources for quota check; treating as over-quota");
+                            return Err(rusternetes_common::Error::Forbidden(format!(
+                                "could not verify quota for {}: {}",
+                                limit_key, e
+                            )));
+                        }
+                    };
                     if current.len() as i64 >= limit {
                         return Err(rusternetes_common::Error::Forbidden(format!(
                             "exceeded quota: {}, requested: 1, used: {}, limited: {}",


### PR DESCRIPTION
## Problem

\`check_count_quota\` used \`unwrap_or_default()\` on two storage list calls. On a transient storage error the controller silently treated the result as an empty list — and then:
- For the quota list: no quotas → admit everything (over-quota resources slip in).
- For the counted-resources list: 0 current resources → always under quota → admit everything.

A real over-quota condition could go unnoticed if the storage backend hiccups.

## Fix

Match \`Err\` explicitly. On quota-list failure, log via \`tracing::warn!\` and skip the check (no quotas configured means no enforcement anyway). On resources-list failure, **fail closed**: return a Forbidden error stating the quota couldn't be verified. Better to reject the create than to silently let it through.

## Verification

\`cargo build --workspace --locked\` clean. No new test failures vs baseline.

Depends on #32 for green CI.