### PR TITLE
perf(async): replace blocking fs/process calls with async equivalents

### DIFF
--- a/crates/api-server/src/handlers/namespace.rs
+++ b/crates/api-server/src/handlers/namespace.rs
@@ -102,10 +102,15 @@ pub async fn create(
     }
 
     // Create kube-root-ca.crt ConfigMap (required by Kubernetes conformance)
-    let ca_cert = std::fs::read_to_string("/etc/kubernetes/pki/ca.crt")
-        .or_else(|_| std::fs::read_to_string("/etc/kubernetes/pki/api-server.crt"))
-        .or_else(|_| std::fs::read_to_string("/root/.rusternetes/certs/ca.crt"))
-        .unwrap_or_else(|_| "".to_string());
+    let ca_cert = match tokio::fs::read_to_string("/etc/kubernetes/pki/ca.crt").await {
+        Ok(s) => s,
+        Err(_) => match tokio::fs::read_to_string("/etc/kubernetes/pki/api-server.crt").await {
+            Ok(s) => s,
+            Err(_) => tokio::fs::read_to_string("/root/.rusternetes/certs/ca.crt")
+                .await
+                .unwrap_or_default(),
+        },
+    };
 
     info!(
         "kube-root-ca.crt for namespace {}: cert_len={}, ns_name={}",

--- a/crates/kube-proxy/src/lib.rs
+++ b/crates/kube-proxy/src/lib.rs
@@ -23,9 +23,21 @@ pub async fn run(storage: Arc<StorageBackend>, config: KubeProxyConfig) -> anyho
         config.node_name
     );
 
-    if let Err(e) = check_iptables() {
-        warn!("iptables check failed: {}. Some features may not work.", e);
-        warn!("Kube-proxy requires iptables to be installed and accessible.");
+    // iptables invocation is blocking; offload to a worker thread so the runtime
+    // is not stalled even briefly during startup.
+    match tokio::task::spawn_blocking(check_iptables).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            warn!("iptables check failed: {}. Some features may not work.", e);
+            warn!("Kube-proxy requires iptables to be installed and accessible.");
+        }
+        Err(e) => {
+            warn!(
+                "iptables check task panicked: {}. Some features may not work.",
+                e
+            );
+            warn!("Kube-proxy requires iptables to be installed and accessible.");
+        }
     }
 
     let kube_proxy = Arc::new(tokio::sync::Mutex::new(KubeProxy::new(Arc::clone(


### PR DESCRIPTION
## Problem

Two blocking calls were buried inside async paths, stalling the tokio runtime on each invocation.

- \`crates/api-server/src/handlers/namespace.rs\`: \`std::fs::read_to_string(...)\` reads the CA cert inside \`pub async fn create(...)\`. Three chained reads, all blocking.
- \`crates/kube-proxy/src/lib.rs\`: \`std::process::Command::new(\"iptables-legacy\")\` runs at startup inside \`pub async fn run(...)\`.

These hold the executor thread for the duration of the I/O — fine on a warm dev box, not fine under load when other tasks are starved.

## Fix

- namespace handler: switch to \`tokio::fs::read_to_string(...).await\` (sequential match ladder preserves the original \"first that succeeds, else empty string\" semantics).
- kube-proxy: wrap the iptables \`Command\` in \`tokio::task::spawn_blocking(check_iptables).await\` so it runs on the blocking pool, not the async worker.

## Verification

\`cargo build --workspace --locked\` clean. No new test failures vs baseline.

Depends on #32 for green CI.