### PR TITLE
fix(spawn): log errors at stream-forwarder break points

### DIFF
--- a/crates/api-server/src/spdy_handlers.rs
+++ b/crates/api-server/src/spdy_handlers.rs
@@ -252,11 +252,16 @@ async fn setup_port_forward(
         loop {
             match spdy_to_tcp.read_frame().await {
                 Ok(Some(frame)) if frame.channel == SpdyChannel::Stdin => {
-                    if tcp_write.write_all(&frame.data).await.is_err() {
+                    if let Err(e) = tcp_write.write_all(&frame.data).await {
+                        tracing::error!(task = "spdy_to_tcp", error = %e, "TCP write failed");
                         break;
                     }
                 }
-                Ok(None) | Err(_) => break,
+                Ok(None) => break,
+                Err(e) => {
+                    tracing::error!(task = "spdy_to_tcp", error = %e, "SPDY read_frame failed");
+                    break;
+                }
                 _ => {}
             }
         }

--- a/crates/kubectl/src/websocket.rs
+++ b/crates/kubectl/src/websocket.rs
@@ -120,7 +120,10 @@ pub async fn exec_stream(ws_url: String, stdin_enabled: bool, _tty_enabled: bool
                     }
                 }
                 Ok(Message::Close(_)) => break,
-                Err(_) => break,
+                Err(e) => {
+                    eprintln!("websocket read task error: {e}");
+                    break;
+                }
                 _ => {}
             }
         }
@@ -145,7 +148,10 @@ pub async fn exec_stream(ws_url: String, stdin_enabled: bool, _tty_enabled: bool
                             break;
                         }
                     }
-                    Err(_) => break,
+                    Err(e) => {
+                        eprintln!("websocket stdin read error: {e}");
+                        break;
+                    }
                 }
             }
 
@@ -278,7 +284,10 @@ async fn handle_port_forward_connection(
                         break;
                     }
                 }
-                Err(_) => break,
+                Err(e) => {
+                    eprintln!("port-forward TCP read error: {e}");
+                    break;
+                }
             }
         }
         let _ = ws_write.close().await;
@@ -303,7 +312,10 @@ async fn handle_port_forward_connection(
                     }
                 }
                 Ok(Message::Close(_)) => break,
-                Err(_) => break,
+                Err(e) => {
+                    eprintln!("port-forward WebSocket read error: {e}");
+                    break;
+                }
                 _ => {}
             }
         }


### PR DESCRIPTION
## Problem

Background \`tokio::spawn\` tasks in the SPDY port-forward forwarder and the kubectl WebSocket read/write loops used \`Err(_) => break\` and \`is_err() { break }\` to terminate on network failure. The \`JoinHandle\` was also dropped, so panics likewise vanished.

Result: when a forwarder died mid-stream there was zero log line indicating why. Users saw \`kubectl exec\` / \`kubectl port-forward\` hang or close with no diagnostic.

## Fix

Add a logged error at each break site so failed forwarders are observable:

- \`crates/api-server/src/spdy_handlers.rs\`: SPDY→TCP forwarder break paths gain \`tracing::error!(task = \"spdy_to_tcp\", error = %e, ...)\`.
- \`crates/kubectl/src/websocket.rs\`: WebSocket read/write loops and port-forward TCP↔WS loops gain \`eprintln!(\"<task> error: {e}\")\` at each \`Err\` break.

Other audit-flagged sites (\`watch_cache.rs\`, \`pod_subresources.rs\`) already log via \`tracing::error!\` — they weren't actually silent. This PR addresses only the truly silent break points.

## Verification

\`cargo build --workspace --locked\` clean. No new test failures vs baseline.

Depends on #32 for green CI.