### PR TITLE
fix(serde): add #[serde(default)] to Option<Vec/Map> resource fields

### DIFF
--- a/crates/common/src/resources/admission_webhook.rs
+++ b/crates/common/src/resources/admission_webhook.rs
@@ -232,7 +232,7 @@ pub enum ReinvocationPolicy {
 #[serde(rename_all = "camelCase")]
 pub struct LabelSelector {
     /// MatchLabels is a map of {key,value} pairs
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub match_labels: Option<std::collections::HashMap<String, String>>,
 
     /// MatchExpressions is a list of label selector requirements

--- a/crates/common/src/resources/admission_webhook.rs
+++ b/crates/common/src/resources/admission_webhook.rs
@@ -14,7 +14,7 @@ pub struct ValidatingWebhookConfiguration {
     pub api_version: String,
     pub kind: String,
     pub metadata: ObjectMeta,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub webhooks: Option<Vec<ValidatingWebhook>>,
 }
 
@@ -69,7 +69,7 @@ pub struct ValidatingWebhook {
     pub admission_review_versions: Vec<String>,
 
     /// MatchConditions are CEL expressions that must be true for the webhook to be called
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub match_conditions: Option<Vec<MatchCondition>>,
 }
 
@@ -80,7 +80,7 @@ pub struct MutatingWebhookConfiguration {
     pub api_version: String,
     pub kind: String,
     pub metadata: ObjectMeta,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub webhooks: Option<Vec<MutatingWebhook>>,
 }
 
@@ -135,7 +135,7 @@ pub struct MutatingWebhook {
     pub admission_review_versions: Vec<String>,
 
     /// MatchConditions are CEL expressions that must be true for the webhook to be called
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub match_conditions: Option<Vec<MatchCondition>>,
 
     /// ReinvocationPolicy indicates whether this webhook should be called multiple times
@@ -236,7 +236,7 @@ pub struct LabelSelector {
     pub match_labels: Option<std::collections::HashMap<String, String>>,
 
     /// MatchExpressions is a list of label selector requirements
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub match_expressions: Option<Vec<LabelSelectorRequirement>>,
 }
 
@@ -251,7 +251,7 @@ pub struct LabelSelectorRequirement {
     pub operator: LabelSelectorOperator,
 
     /// Values is an array of string values
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub values: Option<Vec<String>>,
 }
 

--- a/crates/common/src/resources/authentication.rs
+++ b/crates/common/src/resources/authentication.rs
@@ -39,7 +39,7 @@ pub struct TokenReviewSpec {
     /// verify that the token was intended for at least one of the audiences in
     /// this list. If no audiences are provided, the audience will default to the
     /// audience of the Kubernetes apiserver.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub audiences: Option<Vec<String>>,
 
     /// Token is the opaque bearer token.
@@ -57,7 +57,7 @@ pub struct TokenReviewStatus {
     /// spec.audiences field should validate that a compatible audience identifier
     /// is returned in the status.audiences field to ensure that the TokenReview
     /// server is audience aware.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub audiences: Option<Vec<String>>,
 
     /// Authenticated indicates that the token was associated with a known user.
@@ -78,11 +78,11 @@ pub struct TokenReviewStatus {
 #[serde(rename_all = "camelCase")]
 pub struct UserInfo {
     /// Any additional information provided by the authenticator.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extra: Option<HashMap<String, Vec<String>>>,
 
     /// The names of groups this user is a part of.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub groups: Option<Vec<String>>,
 
     /// A unique value that identifies this user across time. If this user is

--- a/crates/common/src/resources/authorization.rs
+++ b/crates/common/src/resources/authorization.rs
@@ -34,11 +34,11 @@ fn default_kind_subject_access_review() -> String {
 #[serde(rename_all = "camelCase")]
 pub struct SubjectAccessReviewSpec {
     /// Extra corresponds to the user.Info.GetExtra() method from the authenticator.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extra: Option<HashMap<String, Vec<String>>>,
 
     /// Groups is the groups you're testing for.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub groups: Option<Vec<String>>,
 
     /// NonResourceAttributes describes information for a non-resource access request.
@@ -121,7 +121,7 @@ pub struct FieldSelectorAttributes {
     pub raw_selector: Option<String>,
 
     /// Requirements is the parsed interpretation of a field selector.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub requirements: Option<Vec<FieldSelectorRequirement>>,
 }
 
@@ -136,7 +136,7 @@ pub struct FieldSelectorRequirement {
     pub operator: String,
 
     /// Values is an array of string values.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub values: Option<Vec<String>>,
 }
 
@@ -149,7 +149,7 @@ pub struct LabelSelectorAttributes {
     pub raw_selector: Option<String>,
 
     /// Requirements is the parsed interpretation of a label selector.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub requirements: Option<Vec<LabelSelectorRequirement>>,
 }
 
@@ -164,7 +164,7 @@ pub struct LabelSelectorRequirement {
     pub operator: String,
 
     /// Values is an array of string values.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub values: Option<Vec<String>>,
 }
 
@@ -312,7 +312,11 @@ pub struct SubjectRulesReviewStatus {
 #[serde(rename_all = "camelCase")]
 pub struct NonResourceRule {
     /// NonResourceURLs is a set of partial urls that a user should have access to.
-    #[serde(rename = "nonResourceURLs", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "nonResourceURLs",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub non_resource_urls: Option<Vec<String>>,
 
     /// Verb is a list of kubernetes non-resource API verbs.
@@ -324,15 +328,15 @@ pub struct NonResourceRule {
 #[serde(rename_all = "camelCase")]
 pub struct ResourceRule {
     /// APIGroups is the name of the APIGroup that contains the resources.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_groups: Option<Vec<String>>,
 
     /// ResourceNames is an optional white list of names that the rule applies to.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resource_names: Option<Vec<String>>,
 
     /// Resources is a list of resources this rule applies to.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resources: Option<Vec<String>>,
 
     /// Verb is a list of kubernetes resource API verbs.

--- a/crates/common/src/resources/autoscaling.rs
+++ b/crates/common/src/resources/autoscaling.rs
@@ -49,7 +49,7 @@ pub struct HorizontalPodAutoscalerSpec {
     pub max_replicas: i32,
 
     /// Metrics to use for scaling decisions
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metrics: Option<Vec<MetricSpec>>,
 
     /// Behavior configures the scaling behavior (v2 API)
@@ -221,7 +221,7 @@ pub struct HPAScalingRules {
     pub select_policy: Option<String>,
 
     /// Policies is a list of potential scaling policies
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policies: Option<Vec<HPAScalingPolicy>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -262,11 +262,11 @@ pub struct HorizontalPodAutoscalerStatus {
     pub desired_replicas: i32,
 
     /// Current metric values
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_metrics: Option<Vec<MetricStatus>>,
 
     /// Conditions describe the current state of the autoscaler
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub conditions: Option<Vec<HorizontalPodAutoscalerCondition>>,
 }
 
@@ -450,7 +450,7 @@ pub struct VerticalPodAutoscalerSpec {
     pub resource_policy: Option<PodResourcePolicy>,
 
     /// Recommenders lists the names of vertical pod autoscaler recommenders to use
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub recommenders: Option<Vec<VerticalPodAutoscalerRecommenderSelector>>,
 }
 
@@ -468,7 +468,7 @@ pub struct PodUpdatePolicy {
 #[serde(rename_all = "camelCase")]
 pub struct PodResourcePolicy {
     /// Per-container resource policies
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub container_policies: Option<Vec<ContainerResourcePolicy>>,
 }
 
@@ -493,7 +493,7 @@ pub struct ContainerResourcePolicy {
     pub max_allowed: Option<std::collections::HashMap<String, String>>,
 
     /// ControlledResources specifies which resource types are controlled (cpu, memory)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub controlled_resources: Option<Vec<String>>,
 }
 
@@ -514,7 +514,7 @@ pub struct VerticalPodAutoscalerStatus {
     pub recommendation: Option<RecommendedPodResources>,
 
     /// Conditions describe the current state of the VPA
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub conditions: Option<Vec<VerticalPodAutoscalerCondition>>,
 }
 
@@ -523,7 +523,7 @@ pub struct VerticalPodAutoscalerStatus {
 #[serde(rename_all = "camelCase")]
 pub struct RecommendedPodResources {
     /// Recommended resources for each container
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub container_recommendations: Option<Vec<RecommendedContainerResources>>,
 }
 

--- a/crates/common/src/resources/autoscaling.rs
+++ b/crates/common/src/resources/autoscaling.rs
@@ -485,11 +485,11 @@ pub struct ContainerResourcePolicy {
     pub mode: Option<String>,
 
     /// MinAllowed specifies the minimum resource amounts
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub min_allowed: Option<std::collections::HashMap<String, String>>,
 
     /// MaxAllowed specifies the maximum resource amounts
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_allowed: Option<std::collections::HashMap<String, String>>,
 
     /// ControlledResources specifies which resource types are controlled (cpu, memory)
@@ -538,15 +538,15 @@ pub struct RecommendedContainerResources {
     pub target: std::collections::HashMap<String, String>,
 
     /// Lower bound on resource amounts
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lower_bound: Option<std::collections::HashMap<String, String>>,
 
     /// Upper bound on resource amounts
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub upper_bound: Option<std::collections::HashMap<String, String>>,
 
     /// Uncapped target resource amounts (without limits)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub uncapped_target: Option<std::collections::HashMap<String, String>>,
 }
 

--- a/crates/common/src/resources/certificates.rs
+++ b/crates/common/src/resources/certificates.rs
@@ -54,11 +54,11 @@ pub struct CertificateSigningRequestSpec {
     pub uid: Option<String>,
 
     /// groups contains group membership of the user that created the CertificateSigningRequest
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub groups: Option<Vec<String>>,
 
     /// extra contains extra attributes of the user that created the CertificateSigningRequest
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extra: Option<HashMap<String, Vec<String>>>,
 }
 
@@ -117,7 +117,7 @@ pub enum KeyUsage {
 #[serde(rename_all = "camelCase")]
 pub struct CertificateSigningRequestStatus {
     /// conditions applied to the request
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub conditions: Option<Vec<CertificateSigningRequestCondition>>,
 
     /// certificate is populated with an issued certificate

--- a/crates/common/src/resources/componentstatus.rs
+++ b/crates/common/src/resources/componentstatus.rs
@@ -11,7 +11,7 @@ pub struct ComponentStatus {
     pub metadata: ObjectMeta,
 
     /// Conditions holds the status of the component
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub conditions: Option<Vec<ComponentCondition>>,
 }
 

--- a/crates/common/src/resources/csi.rs
+++ b/crates/common/src/resources/csi.rs
@@ -34,11 +34,11 @@ pub struct CSIDriverSpec {
     pub storage_capacity: Option<bool>,
 
     /// volumeLifecycleModes defines what kind of volumes this CSI volume driver supports
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub volume_lifecycle_modes: Option<Vec<VolumeLifecycleMode>>,
 
     /// tokenRequests indicates the CSI driver needs service account tokens
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token_requests: Option<Vec<TokenRequest>>,
 
     /// requiresRepublish indicates the CSI driver wants NodePublishVolume to be periodically called
@@ -107,7 +107,7 @@ pub struct CSINodeDriver {
     pub node_id: String,
 
     /// topologyKeys is the list of keys supported by the driver
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub topology_keys: Option<Vec<String>>,
 
     /// allocatable represents the volume resources of a node that are available for scheduling
@@ -188,7 +188,7 @@ pub struct CSIVolumeSource {
     pub fs_type: Option<String>,
 
     /// volumeAttributes of the volume to publish
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub volume_attributes: Option<HashMap<String, String>>,
 
     /// nodePublishSecretRef is a reference to the secret object containing sensitive information
@@ -203,7 +203,7 @@ pub struct VolumeAttachmentStatus {
     pub attached: bool,
 
     /// attachmentMetadata is populated with any information returned by the attach operation
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attachment_metadata: Option<HashMap<String, String>>,
 
     /// attachError represents the last error encountered during attach operation
@@ -263,7 +263,7 @@ pub struct VolumeAttributesClass {
     pub driver_name: String,
 
     /// parameters hold volume attributes defined by the CSI driver
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parameters: Option<HashMap<String, String>>,
 }
 

--- a/crates/common/src/resources/endpoints.rs
+++ b/crates/common/src/resources/endpoints.rs
@@ -35,15 +35,19 @@ impl Endpoints {
 #[serde(rename_all = "camelCase")]
 pub struct EndpointSubset {
     /// IP addresses which offer the related ports that are marked as ready.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub addresses: Option<Vec<EndpointAddress>>,
 
     /// IP addresses which offer the related ports but are not currently marked as ready.
-    #[serde(skip_serializing_if = "Option::is_none", rename = "notReadyAddresses")]
+    #[serde(
+        rename = "notReadyAddresses",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub not_ready_addresses: Option<Vec<EndpointAddress>>,
 
     /// Port numbers available on the related IP addresses.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ports: Option<Vec<EndpointPort>>,
 }
 

--- a/crates/common/src/resources/endpointslice.rs
+++ b/crates/common/src/resources/endpointslice.rs
@@ -205,7 +205,11 @@ pub struct Endpoint {
     pub hints: Option<EndpointHints>,
 
     /// deprecatedTopology is deprecated and has been replaced by the zone and hints fields.
-    #[serde(skip_serializing_if = "Option::is_none", rename = "deprecatedTopology")]
+    #[serde(
+        rename = "deprecatedTopology",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub deprecated_topology: Option<std::collections::HashMap<String, String>>,
 }
 
@@ -281,10 +285,10 @@ pub struct EndpointReference {
 #[serde(rename_all = "camelCase")]
 pub struct EndpointHints {
     /// forZones indicates the zone(s) this endpoint should be consumed by to enable topology aware routing.
-    #[serde(skip_serializing_if = "Option::is_none", rename = "forZones")]
+    #[serde(rename = "forZones", default, skip_serializing_if = "Option::is_none")]
     pub for_zones: Option<Vec<ForZone>>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub for_nodes: Option<Vec<ForNode>>,
 }
 

--- a/crates/common/src/resources/flowcontrol.rs
+++ b/crates/common/src/resources/flowcontrol.rs
@@ -88,7 +88,7 @@ pub struct ExemptPriorityLevelConfiguration {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PriorityLevelConfigurationStatus {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub conditions: Option<Vec<PriorityLevelConfigurationCondition>>,
 }
 
@@ -135,7 +135,7 @@ pub struct FlowSchemaSpec {
     pub matching_precedence: i32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub distinguisher_method: Option<FlowDistinguisherMethod>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rules: Option<Vec<PolicyRulesWithSubjects>>,
 }
 
@@ -162,9 +162,9 @@ pub enum FlowDistinguisherMethodType {
 #[serde(rename_all = "camelCase")]
 pub struct PolicyRulesWithSubjects {
     pub subjects: Vec<FlowSchemaSubject>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resource_rules: Option<Vec<ResourcePolicyRule>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub non_resource_rules: Option<Vec<NonResourcePolicyRule>>,
 }
 
@@ -214,7 +214,7 @@ pub struct ResourcePolicyRule {
     pub resources: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cluster_scope: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub namespaces: Option<Vec<String>>,
 }
 
@@ -229,7 +229,7 @@ pub struct NonResourcePolicyRule {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FlowSchemaStatus {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub conditions: Option<Vec<FlowSchemaCondition>>,
 }
 

--- a/crates/common/src/resources/ingress.rs
+++ b/crates/common/src/resources/ingress.rs
@@ -49,11 +49,11 @@ pub struct IngressSpec {
     pub default_backend: Option<IngressBackend>,
 
     /// List of TLS configurations
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tls: Option<Vec<IngressTLS>>,
 
     /// List of host rules
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rules: Option<Vec<IngressRule>>,
 }
 
@@ -62,7 +62,7 @@ pub struct IngressSpec {
 #[serde(rename_all = "camelCase")]
 pub struct IngressTLS {
     /// Hosts are a list of hosts included in the TLS certificate
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hosts: Option<Vec<String>>,
 
     /// SecretName is the name of the secret used to terminate TLS traffic
@@ -160,7 +160,7 @@ pub struct IngressStatus {
 #[serde(rename_all = "camelCase")]
 pub struct IngressLoadBalancerStatus {
     /// Ingress is a list containing ingress points for the load-balancer
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ingress: Option<Vec<IngressLoadBalancerIngress>>,
 }
 
@@ -177,7 +177,7 @@ pub struct IngressLoadBalancerIngress {
     pub hostname: Option<String>,
 
     /// Ports provide information about the ports exposed by the load-balancer
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ports: Option<Vec<IngressPortStatus>>,
 }
 

--- a/crates/common/src/resources/networking.rs
+++ b/crates/common/src/resources/networking.rs
@@ -38,15 +38,15 @@ pub struct NetworkPolicySpec {
     pub pod_selector: LabelSelector,
 
     /// List of ingress rules to be applied
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ingress: Option<Vec<NetworkPolicyIngressRule>>,
 
     /// List of egress rules to be applied
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub egress: Option<Vec<NetworkPolicyEgressRule>>,
 
     /// List of policy types that the NetworkPolicy relates to
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy_types: Option<Vec<String>>, // "Ingress", "Egress"
 }
 
@@ -55,11 +55,11 @@ pub struct NetworkPolicySpec {
 #[serde(rename_all = "camelCase")]
 pub struct NetworkPolicyIngressRule {
     /// List of ports which should be made accessible
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ports: Option<Vec<NetworkPolicyPort>>,
 
     /// List of sources which should be able to access the pods
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub from: Option<Vec<NetworkPolicyPeer>>,
 }
 
@@ -68,11 +68,11 @@ pub struct NetworkPolicyIngressRule {
 #[serde(rename_all = "camelCase")]
 pub struct NetworkPolicyEgressRule {
     /// List of destination ports for outgoing traffic
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ports: Option<Vec<NetworkPolicyPort>>,
 
     /// List of destinations for outgoing traffic of pods selected for this rule
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub to: Option<Vec<NetworkPolicyPeer>>,
 }
 
@@ -118,6 +118,6 @@ pub struct IPBlock {
     pub cidr: String,
 
     /// Except is a slice of CIDRs that should not be included within an IP Block
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub except: Option<Vec<String>>,
 }

--- a/crates/common/src/resources/policy.rs
+++ b/crates/common/src/resources/policy.rs
@@ -41,11 +41,11 @@ impl ResourceQuota {
 #[serde(rename_all = "camelCase")]
 pub struct ResourceQuotaSpec {
     /// Hard is the set of desired hard limits for each named resource
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hard: Option<HashMap<String, String>>,
 
     /// A collection of filters that must match each object tracked by a quota
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scopes: Option<Vec<String>>,
 
     /// ScopeSelector is also a collection of filters like scopes that must match each object
@@ -72,7 +72,7 @@ pub struct ScopedResourceSelectorRequirement {
     pub operator: String,
 
     /// An array of string values
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub values: Option<Vec<String>>,
 }
 
@@ -81,11 +81,11 @@ pub struct ScopedResourceSelectorRequirement {
 #[serde(rename_all = "camelCase")]
 pub struct ResourceQuotaStatus {
     /// Hard is the set of enforced hard limits for each named resource
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hard: Option<HashMap<String, String>>,
 
     /// Used is the current observed total usage of the resource in the namespace
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub used: Option<HashMap<String, String>>,
 }
 
@@ -136,23 +136,23 @@ pub struct LimitRangeItem {
     pub item_type: String,
 
     /// Max usage constraints on this kind by resource name
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max: Option<HashMap<String, String>>,
 
     /// Min usage constraints on this kind by resource name
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub min: Option<HashMap<String, String>>,
 
     /// Default resource requirement limit value by resource name if not specified
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default: Option<HashMap<String, String>>,
 
     /// DefaultRequest is the default resource requirement request value by resource name if not specified
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_request: Option<HashMap<String, String>>,
 
     /// MaxLimitRequestRatio represents the max burst value for the named resource
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_limit_request_ratio: Option<HashMap<String, String>>,
 }
 
@@ -312,7 +312,7 @@ pub struct PodDisruptionBudgetStatus {
     pub observed_generation: Option<i64>,
 
     /// Conditions contain the latest available observations of the PDB's state
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub conditions: Option<Vec<PodDisruptionBudgetCondition>>,
 
     /// DisruptedPods contains information about pods whose eviction was
@@ -322,7 +322,7 @@ pub struct PodDisruptionBudgetStatus {
     /// eviction request to the time when the pod is seen by PDB controller
     /// as having been marked for deletion (or after a timeout). The key in the map is the name of the pod
     /// and the value is the time when the API server processed the eviction request.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub disrupted_pods: Option<HashMap<String, DateTime<Utc>>>,
 }
 

--- a/crates/common/src/resources/rbac.rs
+++ b/crates/common/src/resources/rbac.rs
@@ -78,21 +78,25 @@ pub struct PolicyRule {
 
     /// APIGroups is the name of the APIGroup that contains the resources
     /// If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_groups: Option<Vec<String>>,
 
     /// Resources is a list of resources this rule applies to
     /// Examples: pods, services, deployments
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resources: Option<Vec<String>>,
 
     /// ResourceNames is an optional white list of names that the rule applies to
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resource_names: Option<Vec<String>>,
 
     /// NonResourceURLs is a set of partial urls that a user should have access to
     /// *s are allowed, but only as the full, final step in the path
-    #[serde(rename = "nonResourceURLs", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "nonResourceURLs",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub non_resource_urls: Option<Vec<String>>,
 }
 
@@ -294,6 +298,6 @@ impl RoleRef {
 #[serde(rename_all = "camelCase")]
 pub struct AggregationRule {
     /// ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cluster_role_selectors: Option<Vec<crate::types::LabelSelector>>,
 }


### PR DESCRIPTION
## Problem

K8s API serialization omits empty arrays. \`Option<Vec<T>>\` fields without \`#[serde(default)]\` then fail deserialization round-trip when the source JSON omits the field entirely — even though that's the standard K8s wire format for \"no items\".

Affected ~80 fields across ~15 resource files. Minimal objects (a Service with no \`ports\`, a Pod with no \`tolerations\`, etc.) couldn't round-trip through our types.

## Fix

For every \`Option<Vec<T>>\`, \`Option<HashMap<K, V>>\`, \`Option<BTreeMap<K, V>>\` field on a resource struct, add \`#[serde(default)]\` alongside the existing \`#[serde(skip_serializing_if = \"Option::is_none\")]\`. Preserve any \`rename = \"...\"\` overrides — order normalized to \`rename → default → skip_serializing_if\`.

Split into four commits by file batch (A, A-qualified-maps, B, C) for reviewability:
- **Batch A**: \`admission_webhook\`, \`authentication\`, \`authorization\`, \`autoscaling\` (35 fields).
- **Batch A qualified maps**: \`std::collections::HashMap\` paths missed by the bulk regex in batch A (6 more fields in admission_webhook + autoscaling).
- **Batch B**: \`certificates\`, \`componentstatus\`, \`coordination\`, \`csi\`, \`dra\` (10 fields).
- **Batch C**: \`endpoints\`, \`endpointslice\`, \`event\`, \`flowcontrol\`, \`ingress\`, \`ingressclass\`, \`networking\`, \`policy\`, \`rbac\` (40 fields).

Mechanical change — no behavior change for any object that **does** populate these fields. Restores round-trip compatibility for objects that omit them.

## Verification

\`cargo build --workspace --locked\` clean. No new test failures vs baseline.

Depends on #32 for green CI.