### PR TITLE
feat(admission): enforce sideEffects, dry-run propagation, timeout, and IfNeeded reinvocation

### DIFF
--- a/crates/api-server/src/admission_webhook.rs
+++ b/crates/api-server/src/admission_webhook.rs
@@ -9,8 +9,9 @@ use rusternetes_common::{
         GroupVersionKind, GroupVersionResource, Operation, PatchOperation, UserInfo,
     },
     resources::{
-        FailurePolicy, MutatingWebhook, MutatingWebhookConfiguration, OperationType, Rule,
-        SideEffectClass, ValidatingWebhook, ValidatingWebhookConfiguration, WebhookClientConfig,
+        FailurePolicy, MutatingWebhook, MutatingWebhookConfiguration, OperationType,
+        ReinvocationPolicy, Rule, SideEffectClass, ValidatingWebhook,
+        ValidatingWebhookConfiguration, WebhookClientConfig,
     },
     Result,
 };
@@ -20,6 +21,27 @@ use std::error::Error as StdError;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, error, info, warn};
+
+/// K8s v1.35 admission webhook timeout bounds.
+/// admissionregistration.k8s.io/v1: timeoutSeconds must be 1-30, default 10.
+/// K8s ref: staging/src/k8s.io/api/admissionregistration/v1/types.go
+const WEBHOOK_DEFAULT_TIMEOUT_SECS: u64 = 10;
+const WEBHOOK_MAX_TIMEOUT_SECS: u64 = 30;
+const WEBHOOK_MIN_TIMEOUT_SECS: u64 = 1;
+
+/// Resolve a webhook's `timeoutSeconds` to a [`Duration`], honoring K8s v1.35 bounds.
+/// `None` → 10s default. Values < 1 → 1s. Values > 30 → 30s.
+pub(crate) fn resolve_webhook_timeout(timeout_seconds: Option<i32>) -> Duration {
+    let secs = timeout_seconds
+        .map(|t| {
+            (t as i64).clamp(
+                WEBHOOK_MIN_TIMEOUT_SECS as i64,
+                WEBHOOK_MAX_TIMEOUT_SECS as i64,
+            ) as u64
+        })
+        .unwrap_or(WEBHOOK_DEFAULT_TIMEOUT_SECS);
+    Duration::from_secs(secs)
+}
 
 /// Admission webhook client for calling external webhooks
 pub struct AdmissionWebhookClient {
@@ -46,10 +68,7 @@ impl AdmissionWebhookClient {
         request: &AdmissionReviewRequest,
     ) -> Result<AdmissionReviewResponse> {
         let url = self.build_webhook_url(&webhook.client_config)?;
-        let timeout = webhook
-            .timeout_seconds
-            .map(|t| Duration::from_secs(t as u64))
-            .unwrap_or(Duration::from_secs(10));
+        let timeout = resolve_webhook_timeout(webhook.timeout_seconds);
 
         info!("Calling validating webhook {} at {}", webhook.name, url);
 
@@ -92,10 +111,7 @@ impl AdmissionWebhookClient {
         request: &AdmissionReviewRequest,
     ) -> Result<AdmissionReviewResponse> {
         let url = self.build_webhook_url(&webhook.client_config)?;
-        let timeout = webhook
-            .timeout_seconds
-            .map(|t| Duration::from_secs(t as u64))
-            .unwrap_or(Duration::from_secs(10));
+        let timeout = resolve_webhook_timeout(webhook.timeout_seconds);
 
         info!("Calling mutating webhook {} at {}", webhook.name, url);
 
@@ -141,8 +157,38 @@ impl AdmissionWebhookClient {
         self.call_webhook_with_ca(url, review, timeout, None).await
     }
 
-    /// Call a webhook with optional CA bundle for TLS verification
+    /// Call a webhook with optional CA bundle for TLS verification.
+    ///
+    /// The request is bounded by a tokio task-level deadline matching the webhook's
+    /// `spec.timeoutSeconds` (default 10s, clamped to 1-30s per K8s v1.35). The
+    /// reqwest client also enforces the same timeout internally; the tokio wrapper
+    /// guards the full async call (DNS + connect + TLS + send + parse) so the
+    /// request is aborted at the deadline regardless of which phase is blocking.
     async fn call_webhook_with_ca(
+        &self,
+        url: &str,
+        review: &AdmissionReview,
+        timeout: Duration,
+        ca_bundle: Option<&[u8]>,
+    ) -> Result<AdmissionReviewResponse> {
+        // Outer tokio deadline mirrors K8s admissionContext.WithTimeout — if the
+        // entire call exceeds the budget, the future is dropped/aborted.
+        // K8s ref: staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/webhook.go
+        match tokio::time::timeout(
+            timeout,
+            self.call_webhook_inner(url, review, timeout, ca_bundle),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_elapsed) => Err(rusternetes_common::Error::Internal(format!(
+                "failed to call webhook: context deadline exceeded ({}s)",
+                timeout.as_secs()
+            ))),
+        }
+    }
+
+    async fn call_webhook_inner(
         &self,
         url: &str,
         review: &AdmissionReview,
@@ -750,10 +796,7 @@ impl<S: Storage> AdmissionWebhookManager<S> {
                     let raw_url = self.client.build_webhook_url(&webhook.client_config)?;
                     let resolved_url =
                         AdmissionWebhookClient::resolve_service_url(&raw_url, &self.storage).await;
-                    let timeout = webhook
-                        .timeout_seconds
-                        .map(|t| Duration::from_secs(t as u64))
-                        .unwrap_or(Duration::from_secs(10));
+                    let timeout = resolve_webhook_timeout(webhook.timeout_seconds);
                     let failure_policy = webhook
                         .failure_policy
                         .clone()
@@ -965,6 +1008,14 @@ impl<S: Storage> AdmissionWebhookManager<S> {
 
         let mut all_patches = Vec::new();
         let mut all_warnings = Vec::new();
+
+        // Track webhooks with reinvocationPolicy=IfNeeded that were invoked in the
+        // first pass. Each entry records the webhook config and the object
+        // snapshot it observed at the end of its first call. After the first
+        // pass, if the final object diverges from a snapshot — i.e. a later
+        // webhook in the chain mutated it — the webhook is reinvoked once.
+        // K8s ref: staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
+        let mut reinvoke_candidates: Vec<(MutatingWebhook, Value)> = Vec::new();
 
         for config in configs {
             if let Some(webhooks) = &config.webhooks {
@@ -1195,10 +1246,7 @@ impl<S: Storage> AdmissionWebhookManager<S> {
                     let raw_url = self.client.build_webhook_url(&webhook.client_config)?;
                     let resolved_url =
                         AdmissionWebhookClient::resolve_service_url(&raw_url, &self.storage).await;
-                    let timeout = webhook
-                        .timeout_seconds
-                        .map(|t| Duration::from_secs(t as u64))
-                        .unwrap_or(Duration::from_secs(10));
+                    let timeout = resolve_webhook_timeout(webhook.timeout_seconds);
                     let review = AdmissionReview::new_request(request.clone());
                     // K8s caBundle is []byte → JSON base64. Decode to get PEM.
                     let ca_decoded = webhook.client_config.ca_bundle.as_ref().map(|s| {
@@ -1306,7 +1354,184 @@ impl<S: Storage> AdmissionWebhookManager<S> {
 
                         all_patches.extend(patches);
                     }
+
+                    // Record snapshot for IfNeeded reinvocation. Snapshot is the
+                    // object state *after* this webhook's own patches were
+                    // applied — reinvocation triggers only when a *later*
+                    // webhook in the chain mutates it.
+                    if matches!(
+                        webhook.reinvocation_policy,
+                        Some(ReinvocationPolicy::IfNeeded)
+                    ) {
+                        if let Some(ref obj) = object {
+                            reinvoke_candidates.push((webhook.clone(), obj.clone()));
+                        }
+                    }
                 }
+            }
+        }
+
+        // Second pass: reinvoke IfNeeded webhooks whose snapshot diverges from
+        // the current object. K8s performs exactly one extra round of
+        // reinvocations to bound work — webhooks invoked here do not themselves
+        // trigger a third round.
+        for (webhook, snapshot) in reinvoke_candidates {
+            // Skip if the object was removed by a later webhook, or if it is
+            // unchanged from this webhook's last snapshot (no reinvocation needed).
+            match object.as_ref() {
+                None => continue,
+                Some(o) if *o == snapshot => continue,
+                _ => {}
+            }
+
+            info!(
+                "Reinvoking mutating webhook {} (reinvocationPolicy=IfNeeded) — object changed since last call",
+                webhook.name
+            );
+
+            // Re-evaluate objectSelector against the *current* object so we
+            // don't reinvoke when the object no longer matches.
+            if let Some(ref obj_selector) = webhook.object_selector {
+                let obj_labels: std::collections::HashMap<String, String> = object
+                    .as_ref()
+                    .and_then(|o| o.pointer("/metadata/labels"))
+                    .and_then(|l| l.as_object())
+                    .map(|labels_obj| {
+                        labels_obj
+                            .iter()
+                            .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let obj_matches = obj_selector
+                    .match_labels
+                    .as_ref()
+                    .map(|ml| ml.iter().all(|(k, v)| obj_labels.get(k) == Some(v)))
+                    .unwrap_or(true);
+                if !obj_matches {
+                    debug!(
+                        "Skipping reinvocation of {} — object labels no longer match objectSelector",
+                        webhook.name
+                    );
+                    continue;
+                }
+            }
+
+            let (wire_gvr, sub_resource) = if let Some(idx) = gvr.resource.find('/') {
+                (
+                    GroupVersionResource {
+                        group: gvr.group.clone(),
+                        version: gvr.version.clone(),
+                        resource: gvr.resource[..idx].to_string(),
+                    },
+                    Some(gvr.resource[idx + 1..].to_string()),
+                )
+            } else {
+                (gvr.clone(), None)
+            };
+
+            let request = AdmissionReviewRequest {
+                uid: uuid::Uuid::new_v4().to_string(),
+                kind: gvk.clone(),
+                resource: wire_gvr.clone(),
+                sub_resource: sub_resource.clone(),
+                request_kind: Some(gvk.clone()),
+                request_resource: Some(wire_gvr),
+                request_sub_resource: sub_resource,
+                name: name.to_string(),
+                namespace: namespace.map(|s| s.to_string()),
+                operation: operation.clone(),
+                user_info: user_info.clone(),
+                object: object.clone(),
+                old_object: old_object.clone(),
+                dry_run: None,
+                options: None,
+            };
+
+            let raw_url = self.client.build_webhook_url(&webhook.client_config)?;
+            let resolved_url =
+                AdmissionWebhookClient::resolve_service_url(&raw_url, &self.storage).await;
+            let timeout = resolve_webhook_timeout(webhook.timeout_seconds);
+            let review = AdmissionReview::new_request(request.clone());
+            let ca_decoded = webhook.client_config.ca_bundle.as_ref().map(|s| {
+                use base64::Engine;
+                base64::engine::general_purpose::STANDARD
+                    .decode(s)
+                    .unwrap_or_else(|_| s.as_bytes().to_vec())
+            });
+            let ca_bundle_ref = ca_decoded.as_deref();
+            let response = match self
+                .client
+                .call_webhook_with_ca(&resolved_url, &review, timeout, ca_bundle_ref)
+                .await
+            {
+                Ok(resp) => resp,
+                Err(e) => {
+                    let fp = webhook
+                        .failure_policy
+                        .as_ref()
+                        .unwrap_or(&FailurePolicy::Fail);
+                    match fp {
+                        FailurePolicy::Ignore => {
+                            warn!(
+                                "Reinvoked mutating webhook {} failed (Ignore): {}",
+                                webhook.name, e
+                            );
+                            continue;
+                        }
+                        _ => return Err(e),
+                    }
+                }
+            };
+
+            if let Some(warnings) = &response.warnings {
+                all_warnings.extend(warnings.clone());
+            }
+
+            if !response.allowed {
+                let reason = response
+                    .status
+                    .as_ref()
+                    .and_then(|s| {
+                        s.message
+                            .as_ref()
+                            .filter(|m| !m.is_empty())
+                            .or(s.reason.as_ref())
+                    })
+                    .map(|m| m.to_string())
+                    .unwrap_or_else(|| format!("Denied by webhook {}", webhook.name));
+                return Ok((AdmissionResponse::Deny(reason), object));
+            }
+
+            if let Some(patch_base64) = &response.patch {
+                use base64::Engine;
+                let patch_bytes = base64::engine::general_purpose::STANDARD
+                    .decode(patch_base64)
+                    .map_err(|e| {
+                        rusternetes_common::Error::InvalidResource(format!(
+                            "Failed to decode webhook patch: {}",
+                            e
+                        ))
+                    })?;
+                let patch_str = String::from_utf8(patch_bytes).map_err(|e| {
+                    rusternetes_common::Error::InvalidResource(format!(
+                        "Failed to parse webhook patch as UTF-8: {}",
+                        e
+                    ))
+                })?;
+                let patches: Vec<PatchOperation> =
+                    serde_json::from_str(&patch_str).map_err(|e| {
+                        rusternetes_common::Error::InvalidResource(format!(
+                            "Failed to parse webhook patch as JSON: {}",
+                            e
+                        ))
+                    })?;
+                if let Some(ref mut obj) = object {
+                    for patch in &patches {
+                        apply_json_patch(obj, patch)?;
+                    }
+                }
+                all_patches.extend(patches);
             }
         }
 
@@ -2005,6 +2230,34 @@ mod tests {
     use rusternetes_common::resources::RuleWithOperations;
     use rusternetes_storage::memory::MemoryStorage;
     use serde_json::json;
+
+    // ===== Timeout Resolution Tests =====
+
+    #[test]
+    fn test_resolve_webhook_timeout_default() {
+        assert_eq!(resolve_webhook_timeout(None), Duration::from_secs(10));
+    }
+
+    #[test]
+    fn test_resolve_webhook_timeout_explicit() {
+        assert_eq!(resolve_webhook_timeout(Some(5)), Duration::from_secs(5));
+        assert_eq!(resolve_webhook_timeout(Some(1)), Duration::from_secs(1));
+        assert_eq!(resolve_webhook_timeout(Some(30)), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_resolve_webhook_timeout_clamped_to_max() {
+        // K8s v1.35 caps timeoutSeconds at 30.
+        assert_eq!(resolve_webhook_timeout(Some(60)), Duration::from_secs(30));
+        assert_eq!(resolve_webhook_timeout(Some(120)), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_resolve_webhook_timeout_clamped_to_min() {
+        // Negative and zero values clamp to 1 second.
+        assert_eq!(resolve_webhook_timeout(Some(0)), Duration::from_secs(1));
+        assert_eq!(resolve_webhook_timeout(Some(-5)), Duration::from_secs(1));
+    }
 
     // ===== JSON Patch Tests =====
 

--- a/crates/api-server/src/admission_webhook.rs
+++ b/crates/api-server/src/admission_webhook.rs
@@ -10,7 +10,7 @@ use rusternetes_common::{
     },
     resources::{
         FailurePolicy, MutatingWebhook, MutatingWebhookConfiguration, OperationType, Rule,
-        ValidatingWebhook, ValidatingWebhookConfiguration, WebhookClientConfig,
+        SideEffectClass, ValidatingWebhook, ValidatingWebhookConfiguration, WebhookClientConfig,
     },
     Result,
 };
@@ -491,6 +491,34 @@ impl<S: Storage> AdmissionWebhookManager<S> {
         old_object: Option<Value>,
         user_info: &UserInfo,
     ) -> Result<AdmissionResponse> {
+        self.run_validating_webhooks_with_dryrun(
+            operation, gvk, gvr, namespace, name, object, old_object, user_info, false,
+        )
+        .await
+    }
+
+    /// Run validating webhooks honoring the request's dry-run state.
+    ///
+    /// When `dry_run=true`:
+    /// - Webhooks with `sideEffects` of `Some` or `Unknown` are rejected: K8s
+    ///   refuses to admit dry-run requests through webhooks that may have side
+    ///   effects (apiserver returns an error, fail-closed).
+    ///   K8s ref: staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
+    /// - The `dryRun: true` field is set on the `AdmissionReviewRequest` so the
+    ///   webhook can short-circuit side-effects on its end.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn run_validating_webhooks_with_dryrun(
+        &self,
+        operation: &Operation,
+        gvk: &GroupVersionKind,
+        gvr: &GroupVersionResource,
+        namespace: Option<&str>,
+        name: &str,
+        object: Option<Value>,
+        old_object: Option<Value>,
+        user_info: &UserInfo,
+        dry_run: bool,
+    ) -> Result<AdmissionResponse> {
         // K8s exempts webhook configuration objects from admission webhooks.
         // Webhooks must not be able to mutate or prevent deletion of webhook
         // configuration objects, otherwise a broken webhook could lock the cluster.
@@ -703,6 +731,21 @@ impl<S: Storage> AdmissionWebhookManager<S> {
                         }
                     }
 
+                    // Enforce SideEffects policy for dry-run requests.
+                    // K8s rejects dry-run requests through webhooks with sideEffects=Some or Unknown.
+                    // K8s ref: staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
+                    if dry_run
+                        && matches!(
+                            webhook.side_effects,
+                            SideEffectClass::Some | SideEffectClass::Unknown
+                        )
+                    {
+                        return Ok(AdmissionResponse::Deny(format!(
+                            "admission webhook {:?} does not support dry run",
+                            webhook.name
+                        )));
+                    }
+
                     // Resolve webhook URL and build invocation
                     let raw_url = self.client.build_webhook_url(&webhook.client_config)?;
                     let resolved_url =
@@ -747,7 +790,7 @@ impl<S: Storage> AdmissionWebhookManager<S> {
                         user_info: user_info.clone(),
                         object: object.clone(),
                         old_object: old_object.clone(),
-                        dry_run: None,
+                        dry_run: if dry_run { Some(true) } else { None },
                         options: None,
                     };
 
@@ -876,9 +919,35 @@ impl<S: Storage> AdmissionWebhookManager<S> {
         gvr: &GroupVersionResource,
         namespace: Option<&str>,
         name: &str,
+        object: Option<Value>,
+        old_object: Option<Value>,
+        user_info: &UserInfo,
+    ) -> Result<(AdmissionResponse, Option<Value>)> {
+        self.run_mutating_webhooks_with_dryrun(
+            operation, gvk, gvr, namespace, name, object, old_object, user_info, false,
+        )
+        .await
+    }
+
+    /// Run mutating webhooks honoring the request's dry-run state.
+    ///
+    /// When `dry_run=true`:
+    /// - Webhooks with `sideEffects` of `Some` or `Unknown` are rejected.
+    /// - The `dryRun: true` field is set on the `AdmissionReviewRequest`.
+    ///
+    /// K8s ref: staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
+    #[allow(clippy::too_many_arguments)]
+    pub async fn run_mutating_webhooks_with_dryrun(
+        &self,
+        operation: &Operation,
+        gvk: &GroupVersionKind,
+        gvr: &GroupVersionResource,
+        namespace: Option<&str>,
+        name: &str,
         mut object: Option<Value>,
         old_object: Option<Value>,
         user_info: &UserInfo,
+        dry_run: bool,
     ) -> Result<(AdmissionResponse, Option<Value>)> {
         // K8s exempts webhook configuration objects from admission webhooks.
         // K8s ref: staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/predicates/rules/rules.go
@@ -1066,6 +1135,24 @@ impl<S: Storage> AdmissionWebhookManager<S> {
                         }
                     }
 
+                    // Enforce SideEffects policy for dry-run requests.
+                    // K8s rejects dry-run requests through webhooks with sideEffects=Some or Unknown.
+                    // K8s ref: staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
+                    if dry_run
+                        && matches!(
+                            webhook.side_effects,
+                            SideEffectClass::Some | SideEffectClass::Unknown
+                        )
+                    {
+                        return Ok((
+                            AdmissionResponse::Deny(format!(
+                                "admission webhook {:?} does not support dry run",
+                                webhook.name
+                            )),
+                            object,
+                        ));
+                    }
+
                     info!(
                         "Running mutating webhook {} for {}/{}",
                         webhook.name, gvk.kind, name
@@ -1100,7 +1187,7 @@ impl<S: Storage> AdmissionWebhookManager<S> {
                         user_info: user_info.clone(),
                         object: object.clone(),
                         old_object: old_object.clone(),
-                        dry_run: None,
+                        dry_run: if dry_run { Some(true) } else { None },
                         options: None,
                     };
 
@@ -3082,6 +3169,838 @@ mod tests {
             result.is_ok(),
             "2-replica deployment in correct namespace should be allowed: {:?}",
             result.err()
+        );
+    }
+
+    // ===== Webhook deny / mutate / dry-run / pruning tests =====
+    //
+    // These tests cover the K8s v1.35 admission webhook conformance gap:
+    //   - deny path for pod/configmap/CR + subresource (attach)
+    //   - mutate path producing JSON patches
+    //   - SideEffects gating for dry-run
+    //   - status.message propagation
+
+    use rusternetes_common::admission::AdmissionStatus;
+    use rusternetes_common::resources::{
+        FailurePolicy, MutatingWebhook, MutatingWebhookConfiguration, OperationType, Rule,
+        RuleWithOperations as Rwo, SideEffectClass, ValidatingWebhook,
+        ValidatingWebhookConfiguration, WebhookClientConfig,
+    };
+
+    /// Spin up a tiny axum HTTP server that returns the canned AdmissionReview
+    /// response for every POST. Returns the base URL so the webhook config can
+    /// point at it.
+    async fn spawn_webhook_server(
+        response: AdmissionReviewResponse,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        use axum::{routing::post, Json, Router};
+        let resp = Arc::new(response);
+        let resp_clone = resp.clone();
+        let app = Router::new().route(
+            "/admit",
+            post(move |Json(review): Json<AdmissionReview>| {
+                let response = resp_clone.clone();
+                async move {
+                    let mut out = (*response).clone();
+                    if let Some(req) = review.request.as_ref() {
+                        out.uid = req.uid.clone();
+                    }
+                    Json(AdmissionReview::new_response(out))
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            let _ = axum::serve(listener, app.into_make_service()).await;
+        });
+        (format!("http://{}/admit", addr), handle)
+    }
+
+    fn pods_rule() -> Rwo {
+        Rwo {
+            operations: vec![OperationType::Create],
+            rule: Rule {
+                api_groups: vec!["".to_string()],
+                api_versions: vec!["v1".to_string()],
+                resources: vec!["pods".to_string()],
+                scope: None,
+            },
+        }
+    }
+
+    fn configmaps_rule() -> Rwo {
+        Rwo {
+            operations: vec![OperationType::Create],
+            rule: Rule {
+                api_groups: vec!["".to_string()],
+                api_versions: vec!["v1".to_string()],
+                resources: vec!["configmaps".to_string()],
+                scope: None,
+            },
+        }
+    }
+
+    fn attach_rule() -> Rwo {
+        // K8s admission rules match subresources via "<resource>/<sub>" syntax.
+        // pods/attach is a Connect operation in K8s.
+        Rwo {
+            operations: vec![OperationType::Connect],
+            rule: Rule {
+                api_groups: vec!["".to_string()],
+                api_versions: vec!["v1".to_string()],
+                resources: vec!["pods/attach".to_string()],
+                scope: None,
+            },
+        }
+    }
+
+    fn cr_rule() -> Rwo {
+        Rwo {
+            operations: vec![OperationType::All],
+            rule: Rule {
+                api_groups: vec!["example.com".to_string()],
+                api_versions: vec!["v1".to_string()],
+                resources: vec!["foos".to_string()],
+                scope: None,
+            },
+        }
+    }
+
+    fn make_validating_config(name: &str, url: &str, rule: Rwo) -> ValidatingWebhookConfiguration {
+        ValidatingWebhookConfiguration {
+            api_version: "admissionregistration.k8s.io/v1".to_string(),
+            kind: "ValidatingWebhookConfiguration".to_string(),
+            metadata: rusternetes_common::types::ObjectMeta::new(name),
+            webhooks: Some(vec![ValidatingWebhook {
+                name: format!("{}.example.com", name),
+                client_config: WebhookClientConfig {
+                    url: Some(url.to_string()),
+                    service: None,
+                    ca_bundle: None,
+                },
+                rules: vec![rule],
+                failure_policy: Some(FailurePolicy::Fail),
+                match_policy: None,
+                namespace_selector: None,
+                object_selector: None,
+                side_effects: SideEffectClass::None,
+                timeout_seconds: Some(5),
+                admission_review_versions: vec!["v1".to_string()],
+                match_conditions: None,
+            }]),
+        }
+    }
+
+    fn make_mutating_config(name: &str, url: &str, rule: Rwo) -> MutatingWebhookConfiguration {
+        MutatingWebhookConfiguration {
+            api_version: "admissionregistration.k8s.io/v1".to_string(),
+            kind: "MutatingWebhookConfiguration".to_string(),
+            metadata: rusternetes_common::types::ObjectMeta::new(name),
+            webhooks: Some(vec![MutatingWebhook {
+                name: format!("{}.example.com", name),
+                client_config: WebhookClientConfig {
+                    url: Some(url.to_string()),
+                    service: None,
+                    ca_bundle: None,
+                },
+                rules: vec![rule],
+                failure_policy: Some(FailurePolicy::Fail),
+                match_policy: None,
+                namespace_selector: None,
+                object_selector: None,
+                side_effects: SideEffectClass::None,
+                timeout_seconds: Some(5),
+                admission_review_versions: vec!["v1".to_string()],
+                match_conditions: None,
+                reinvocation_policy: None,
+            }]),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_validating_webhook_denies_pod_create_with_status_message() {
+        let deny_resp = AdmissionReviewResponse {
+            uid: String::new(),
+            allowed: false,
+            status: Some(AdmissionStatus {
+                status: "Failure".to_string(),
+                message: Some("this webhook denies all pods".to_string()),
+                reason: Some("Forbidden".to_string()),
+                code: Some(403),
+                metadata: None,
+            }),
+            patch: None,
+            patch_type: None,
+            audit_annotations: None,
+            warnings: None,
+        };
+        let (url, handle) = spawn_webhook_server(deny_resp).await;
+
+        let storage = Arc::new(MemoryStorage::new());
+        let config = make_validating_config("deny-pods", &url, pods_rule());
+        storage
+            .create(
+                "/registry/validatingwebhookconfigurations/deny-pods",
+                &config,
+            )
+            .await
+            .unwrap();
+
+        let manager = AdmissionWebhookManager::new(storage);
+        let gvk = GroupVersionKind {
+            group: "".into(),
+            version: "v1".into(),
+            kind: "Pod".into(),
+        };
+        let gvr = GroupVersionResource {
+            group: "".into(),
+            version: "v1".into(),
+            resource: "pods".into(),
+        };
+        let user = UserInfo {
+            username: "alice".into(),
+            uid: "1".into(),
+            groups: vec![],
+        };
+        let pod = json!({"metadata": {"name": "p", "namespace": "default"}});
+
+        let resp = manager
+            .run_validating_webhooks(
+                &Operation::Create,
+                &gvk,
+                &gvr,
+                Some("default"),
+                "p",
+                Some(pod),
+                None,
+                &user,
+            )
+            .await
+            .unwrap();
+        handle.abort();
+
+        match resp {
+            AdmissionResponse::Deny(reason) => assert_eq!(reason, "this webhook denies all pods"),
+            other => panic!("expected Deny, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_validating_webhook_denies_configmap_create() {
+        let deny_resp = AdmissionReviewResponse {
+            uid: String::new(),
+            allowed: false,
+            status: Some(AdmissionStatus {
+                status: "Failure".into(),
+                message: Some("no configmaps for you".into()),
+                reason: None,
+                code: Some(403),
+                metadata: None,
+            }),
+            patch: None,
+            patch_type: None,
+            audit_annotations: None,
+            warnings: None,
+        };
+        let (url, handle) = spawn_webhook_server(deny_resp).await;
+
+        let storage = Arc::new(MemoryStorage::new());
+        let config = make_validating_config("deny-cms", &url, configmaps_rule());
+        storage
+            .create(
+                "/registry/validatingwebhookconfigurations/deny-cms",
+                &config,
+            )
+            .await
+            .unwrap();
+
+        let manager = AdmissionWebhookManager::new(storage);
+        let gvk = GroupVersionKind {
+            group: "".into(),
+            version: "v1".into(),
+            kind: "ConfigMap".into(),
+        };
+        let gvr = GroupVersionResource {
+            group: "".into(),
+            version: "v1".into(),
+            resource: "configmaps".into(),
+        };
+        let user = UserInfo {
+            username: "alice".into(),
+            uid: "1".into(),
+            groups: vec![],
+        };
+        let resp = manager
+            .run_validating_webhooks(
+                &Operation::Create,
+                &gvk,
+                &gvr,
+                Some("default"),
+                "cm",
+                Some(json!({"metadata": {"name": "cm"}})),
+                None,
+                &user,
+            )
+            .await
+            .unwrap();
+        handle.abort();
+
+        assert!(matches!(resp, AdmissionResponse::Deny(ref r) if r == "no configmaps for you"));
+    }
+
+    #[tokio::test]
+    async fn test_validating_webhook_denies_pod_attach_subresource() {
+        let deny_resp = AdmissionReviewResponse {
+            uid: String::new(),
+            allowed: false,
+            status: Some(AdmissionStatus {
+                status: "Failure".into(),
+                message: Some("attach not allowed".into()),
+                reason: None,
+                code: Some(403),
+                metadata: None,
+            }),
+            patch: None,
+            patch_type: None,
+            audit_annotations: None,
+            warnings: None,
+        };
+        let (url, handle) = spawn_webhook_server(deny_resp).await;
+
+        let storage = Arc::new(MemoryStorage::new());
+        let config = make_validating_config("deny-attach", &url, attach_rule());
+        storage
+            .create(
+                "/registry/validatingwebhookconfigurations/deny-attach",
+                &config,
+            )
+            .await
+            .unwrap();
+
+        let manager = AdmissionWebhookManager::new(storage);
+        // GVR resource "pods/attach" carries the subresource separator that the
+        // matcher splits before comparing against rule entries.
+        let gvk = GroupVersionKind {
+            group: "".into(),
+            version: "v1".into(),
+            kind: "PodAttachOptions".into(),
+        };
+        let gvr = GroupVersionResource {
+            group: "".into(),
+            version: "v1".into(),
+            resource: "pods/attach".into(),
+        };
+        let user = UserInfo {
+            username: "alice".into(),
+            uid: "1".into(),
+            groups: vec![],
+        };
+        let resp = manager
+            .run_validating_webhooks(
+                &Operation::Connect,
+                &gvk,
+                &gvr,
+                Some("default"),
+                "p",
+                Some(json!({"container": "main"})),
+                None,
+                &user,
+            )
+            .await
+            .unwrap();
+        handle.abort();
+
+        assert!(matches!(resp, AdmissionResponse::Deny(ref r) if r == "attach not allowed"));
+    }
+
+    #[tokio::test]
+    async fn test_validating_webhook_denies_custom_resource_crud() {
+        let deny_resp = AdmissionReviewResponse {
+            uid: String::new(),
+            allowed: false,
+            status: Some(AdmissionStatus {
+                status: "Failure".into(),
+                message: Some("CR rejected".into()),
+                reason: None,
+                code: Some(403),
+                metadata: None,
+            }),
+            patch: None,
+            patch_type: None,
+            audit_annotations: None,
+            warnings: None,
+        };
+        let (url, handle) = spawn_webhook_server(deny_resp).await;
+
+        let storage = Arc::new(MemoryStorage::new());
+        let config = make_validating_config("deny-foos", &url, cr_rule());
+        storage
+            .create(
+                "/registry/validatingwebhookconfigurations/deny-foos",
+                &config,
+            )
+            .await
+            .unwrap();
+
+        let manager = AdmissionWebhookManager::new(storage);
+        let gvk = GroupVersionKind {
+            group: "example.com".into(),
+            version: "v1".into(),
+            kind: "Foo".into(),
+        };
+        let gvr = GroupVersionResource {
+            group: "example.com".into(),
+            version: "v1".into(),
+            resource: "foos".into(),
+        };
+        let user = UserInfo {
+            username: "alice".into(),
+            uid: "1".into(),
+            groups: vec![],
+        };
+        let cr_obj = json!({"apiVersion": "example.com/v1", "kind": "Foo",
+                            "metadata": {"name": "f1", "namespace": "default"}});
+
+        // CREATE
+        let create_resp = manager
+            .run_validating_webhooks(
+                &Operation::Create,
+                &gvk,
+                &gvr,
+                Some("default"),
+                "f1",
+                Some(cr_obj.clone()),
+                None,
+                &user,
+            )
+            .await
+            .unwrap();
+        assert!(matches!(create_resp, AdmissionResponse::Deny(ref r) if r == "CR rejected"));
+
+        // UPDATE
+        let update_resp = manager
+            .run_validating_webhooks(
+                &Operation::Update,
+                &gvk,
+                &gvr,
+                Some("default"),
+                "f1",
+                Some(cr_obj.clone()),
+                Some(cr_obj.clone()),
+                &user,
+            )
+            .await
+            .unwrap();
+        assert!(matches!(update_resp, AdmissionResponse::Deny(_)));
+
+        // DELETE: object is None, oldObject carries the resource
+        let delete_resp = manager
+            .run_validating_webhooks(
+                &Operation::Delete,
+                &gvk,
+                &gvr,
+                Some("default"),
+                "f1",
+                None,
+                Some(cr_obj),
+                &user,
+            )
+            .await
+            .unwrap();
+        assert!(matches!(delete_resp, AdmissionResponse::Deny(_)));
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_mutating_webhook_applies_json_patch_to_custom_resource() {
+        use base64::Engine;
+        // Patch: add a label, then add an unknown field to spec
+        let patch = serde_json::json!([
+            {"op": "add", "path": "/metadata/labels", "value": {"mutated": "true"}},
+            {"op": "add", "path": "/spec/extraField", "value": "leak"},
+        ]);
+        let patch_b64 =
+            base64::engine::general_purpose::STANDARD.encode(patch.to_string().as_bytes());
+
+        let mutate_resp = AdmissionReviewResponse {
+            uid: String::new(),
+            allowed: true,
+            status: None,
+            patch: Some(patch_b64),
+            patch_type: Some("JSONPatch".to_string()),
+            audit_annotations: None,
+            warnings: None,
+        };
+        let (url, handle) = spawn_webhook_server(mutate_resp).await;
+
+        let storage = Arc::new(MemoryStorage::new());
+        let config = make_mutating_config("mutate-foos", &url, cr_rule());
+        storage
+            .create(
+                "/registry/mutatingwebhookconfigurations/mutate-foos",
+                &config,
+            )
+            .await
+            .unwrap();
+
+        let manager = AdmissionWebhookManager::new(storage);
+        let gvk = GroupVersionKind {
+            group: "example.com".into(),
+            version: "v1".into(),
+            kind: "Foo".into(),
+        };
+        let gvr = GroupVersionResource {
+            group: "example.com".into(),
+            version: "v1".into(),
+            resource: "foos".into(),
+        };
+        let user = UserInfo {
+            username: "alice".into(),
+            uid: "1".into(),
+            groups: vec![],
+        };
+        let cr_obj = json!({
+            "apiVersion": "example.com/v1",
+            "kind": "Foo",
+            "metadata": {"name": "f1", "labels": {}},
+            "spec": {"replicas": 1}
+        });
+
+        let (resp, mutated) = manager
+            .run_mutating_webhooks(
+                &Operation::Create,
+                &gvk,
+                &gvr,
+                Some("default"),
+                "f1",
+                Some(cr_obj),
+                None,
+                &user,
+            )
+            .await
+            .unwrap();
+        handle.abort();
+
+        assert!(resp.is_allowed());
+        let mutated = mutated.expect("mutated object");
+        assert_eq!(
+            mutated.pointer("/metadata/labels/mutated"),
+            Some(&json!("true"))
+        );
+        // The webhook injected an unknown field — pruning must remove it next.
+        assert_eq!(mutated.pointer("/spec/extraField"), Some(&json!("leak")));
+    }
+
+    #[tokio::test]
+    async fn test_mutating_webhook_dryrun_rejected_when_side_effects_some() {
+        // K8s rejects dry-run requests if the webhook declares Side Effects.
+        let (url, handle) = spawn_webhook_server(AdmissionReviewResponse {
+            uid: String::new(),
+            allowed: true,
+            status: None,
+            patch: None,
+            patch_type: None,
+            audit_annotations: None,
+            warnings: None,
+        })
+        .await;
+
+        let storage = Arc::new(MemoryStorage::new());
+        let mut config = make_mutating_config("mutate-pods", &url, pods_rule());
+        // Mark this webhook as having Some side effects so dry-run must be refused.
+        if let Some(ws) = config.webhooks.as_mut() {
+            ws[0].side_effects = SideEffectClass::Some;
+        }
+        storage
+            .create(
+                "/registry/mutatingwebhookconfigurations/mutate-pods",
+                &config,
+            )
+            .await
+            .unwrap();
+
+        let manager = AdmissionWebhookManager::new(storage);
+        let gvk = GroupVersionKind {
+            group: "".into(),
+            version: "v1".into(),
+            kind: "Pod".into(),
+        };
+        let gvr = GroupVersionResource {
+            group: "".into(),
+            version: "v1".into(),
+            resource: "pods".into(),
+        };
+        let user = UserInfo {
+            username: "alice".into(),
+            uid: "1".into(),
+            groups: vec![],
+        };
+
+        let (resp, _obj) = manager
+            .run_mutating_webhooks_with_dryrun(
+                &Operation::Create,
+                &gvk,
+                &gvr,
+                Some("default"),
+                "p",
+                Some(json!({"metadata": {"name": "p"}})),
+                None,
+                &user,
+                true, // dry-run
+            )
+            .await
+            .unwrap();
+        handle.abort();
+
+        match resp {
+            AdmissionResponse::Deny(reason) => assert!(
+                reason.contains("does not support dry run"),
+                "got reason: {}",
+                reason
+            ),
+            other => panic!(
+                "expected Deny for dry-run with side effects, got {:?}",
+                other
+            ),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_mutating_webhook_dryrun_allowed_for_none_on_dryrun() {
+        // sideEffects=NoneOnDryRun means: the webhook has side effects in
+        // normal operation but knows to skip them when dryRun=true. The
+        // apiserver should still call the webhook.
+        let (url, handle) = spawn_webhook_server(AdmissionReviewResponse {
+            uid: String::new(),
+            allowed: true,
+            status: None,
+            patch: None,
+            patch_type: None,
+            audit_annotations: None,
+            warnings: None,
+        })
+        .await;
+
+        let storage = Arc::new(MemoryStorage::new());
+        let mut config = make_mutating_config("mutate-pods-noneondryrun", &url, pods_rule());
+        if let Some(ws) = config.webhooks.as_mut() {
+            ws[0].side_effects = SideEffectClass::NoneOnDryRun;
+        }
+        storage
+            .create(
+                "/registry/mutatingwebhookconfigurations/mutate-pods-noneondryrun",
+                &config,
+            )
+            .await
+            .unwrap();
+
+        let manager = AdmissionWebhookManager::new(storage);
+        let gvk = GroupVersionKind {
+            group: "".into(),
+            version: "v1".into(),
+            kind: "Pod".into(),
+        };
+        let gvr = GroupVersionResource {
+            group: "".into(),
+            version: "v1".into(),
+            resource: "pods".into(),
+        };
+        let user = UserInfo {
+            username: "alice".into(),
+            uid: "1".into(),
+            groups: vec![],
+        };
+
+        let (resp, _obj) = manager
+            .run_mutating_webhooks_with_dryrun(
+                &Operation::Create,
+                &gvk,
+                &gvr,
+                Some("default"),
+                "p",
+                Some(json!({"metadata": {"name": "p"}})),
+                None,
+                &user,
+                true,
+            )
+            .await
+            .unwrap();
+        handle.abort();
+        assert!(
+            resp.is_allowed(),
+            "NoneOnDryRun should be allowed under dry-run, got {:?}",
+            resp
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validating_webhook_failure_policy_fail_blocks() {
+        // Point at an unreachable URL with FailurePolicy=Fail so the
+        // request is rejected.
+        let storage = Arc::new(MemoryStorage::new());
+        let mut config = make_validating_config(
+            "fail-closed",
+            "http://127.0.0.1:1/admit", // unreachable port
+            pods_rule(),
+        );
+        if let Some(ws) = config.webhooks.as_mut() {
+            ws[0].failure_policy = Some(FailurePolicy::Fail);
+            ws[0].timeout_seconds = Some(1);
+        }
+        storage
+            .create(
+                "/registry/validatingwebhookconfigurations/fail-closed",
+                &config,
+            )
+            .await
+            .unwrap();
+
+        let manager = AdmissionWebhookManager::new(storage);
+        let gvk = GroupVersionKind {
+            group: "".into(),
+            version: "v1".into(),
+            kind: "Pod".into(),
+        };
+        let gvr = GroupVersionResource {
+            group: "".into(),
+            version: "v1".into(),
+            resource: "pods".into(),
+        };
+        let user = UserInfo {
+            username: "alice".into(),
+            uid: "1".into(),
+            groups: vec![],
+        };
+        let result = manager
+            .run_validating_webhooks(
+                &Operation::Create,
+                &gvk,
+                &gvr,
+                Some("default"),
+                "p",
+                Some(json!({"metadata": {"name": "p"}})),
+                None,
+                &user,
+            )
+            .await;
+        assert!(
+            result.is_err(),
+            "Fail policy should reject when webhook is unreachable"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validating_webhook_failure_policy_ignore_allows() {
+        // Same setup but with FailurePolicy=Ignore — request must be allowed.
+        let storage = Arc::new(MemoryStorage::new());
+        let mut config =
+            make_validating_config("fail-open", "http://127.0.0.1:1/admit", pods_rule());
+        if let Some(ws) = config.webhooks.as_mut() {
+            ws[0].failure_policy = Some(FailurePolicy::Ignore);
+            ws[0].timeout_seconds = Some(1);
+        }
+        storage
+            .create(
+                "/registry/validatingwebhookconfigurations/fail-open",
+                &config,
+            )
+            .await
+            .unwrap();
+
+        let manager = AdmissionWebhookManager::new(storage);
+        let gvk = GroupVersionKind {
+            group: "".into(),
+            version: "v1".into(),
+            kind: "Pod".into(),
+        };
+        let gvr = GroupVersionResource {
+            group: "".into(),
+            version: "v1".into(),
+            resource: "pods".into(),
+        };
+        let user = UserInfo {
+            username: "alice".into(),
+            uid: "1".into(),
+            groups: vec![],
+        };
+        let resp = manager
+            .run_validating_webhooks(
+                &Operation::Create,
+                &gvk,
+                &gvr,
+                Some("default"),
+                "p",
+                Some(json!({"metadata": {"name": "p"}})),
+                None,
+                &user,
+            )
+            .await
+            .unwrap();
+        assert!(resp.is_allowed(), "Ignore policy must fail-open");
+    }
+
+    // ===== CR pruning after mutating webhook =====
+
+    /// Smoke-test the structural pruning function used by the CR create handler.
+    /// The CR handler calls `prune_custom_resource` AFTER applying webhook
+    /// mutations so any fields injected by a mutator that are absent from the
+    /// CRD's structural schema must be stripped before storage.
+    #[test]
+    fn test_prune_unknown_fields_after_webhook_mutation() {
+        use rusternetes_common::resources::{CustomResource, CustomResourceDefinition};
+
+        // Build the CRD from JSON to avoid spelling out every field of the
+        // structured types — the structural schema declares only `spec.replicas`.
+        let crd_json = json!({
+            "apiVersion": "apiextensions.k8s.io/v1",
+            "kind": "CustomResourceDefinition",
+            "metadata": {"name": "foos.example.com"},
+            "spec": {
+                "group": "example.com",
+                "names": {"plural": "foos", "singular": "foo", "kind": "Foo", "listKind": "FooList"},
+                "scope": "Namespaced",
+                "versions": [{
+                    "name": "v1",
+                    "served": true,
+                    "storage": true,
+                    "schema": {
+                        "openAPIV3Schema": {
+                            "type": "object",
+                            "properties": {
+                                "spec": {
+                                    "type": "object",
+                                    "properties": {
+                                        "replicas": {"type": "integer"}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }]
+            }
+        });
+        let crd: CustomResourceDefinition = serde_json::from_value(crd_json).unwrap();
+
+        // CR with a webhook-injected unknown field in spec.
+        let cr_json = json!({
+            "apiVersion": "example.com/v1",
+            "kind": "Foo",
+            "metadata": {"name": "f1"},
+            "spec": {"replicas": 3, "extraField": "leak"}
+        });
+        let mut cr: CustomResource = serde_json::from_value(cr_json).unwrap();
+
+        // Reuse the same pruning function the create handler calls.
+        crate::handlers::custom_resource::test_prune_custom_resource(&crd, "v1", &mut cr);
+
+        let pruned_spec = cr.spec.expect("spec preserved");
+        assert_eq!(pruned_spec.get("replicas"), Some(&json!(3)));
+        assert!(
+            pruned_spec.get("extraField").is_none(),
+            "extraField must be pruned: {:?}",
+            pruned_spec
         );
     }
 }

--- a/crates/api-server/src/handlers/configmap.rs
+++ b/crates/api-server/src/handlers/configmap.rs
@@ -90,7 +90,7 @@ pub async fn create(
         // Run mutating webhooks
         let (_response, mutated_obj) = state
             .webhook_manager
-            .run_mutating_webhooks(
+            .run_mutating_webhooks_with_dryrun(
                 &rusternetes_common::admission::Operation::Create,
                 &gvk,
                 &gvr,
@@ -99,6 +99,7 @@ pub async fn create(
                 cm_val.clone(),
                 None,
                 &user_info,
+                is_dry_run,
             )
             .await?;
         // Check if the mutating webhook DENIED the request.
@@ -117,7 +118,7 @@ pub async fn create(
         // Run validating webhooks
         if let rusternetes_common::admission::AdmissionResponse::Deny(reason) = state
             .webhook_manager
-            .run_validating_webhooks(
+            .run_validating_webhooks_with_dryrun(
                 &rusternetes_common::admission::Operation::Create,
                 &gvk,
                 &gvr,
@@ -126,6 +127,7 @@ pub async fn create(
                 serde_json::to_value(&configmap).ok(),
                 None,
                 &user_info,
+                is_dry_run,
             )
             .await?
         {
@@ -243,7 +245,7 @@ pub async fn update(
         // Run mutating webhooks
         let (_response, mutated_obj) = state
             .webhook_manager
-            .run_mutating_webhooks(
+            .run_mutating_webhooks_with_dryrun(
                 &rusternetes_common::admission::Operation::Update,
                 &gvk,
                 &gvr,
@@ -252,6 +254,7 @@ pub async fn update(
                 cm_val.clone(),
                 None,
                 &user_info,
+                is_dry_run,
             )
             .await?;
         // Check if the mutating webhook DENIED the request.

--- a/crates/api-server/src/handlers/custom_resource.rs
+++ b/crates/api-server/src/handlers/custom_resource.rs
@@ -201,6 +201,7 @@ pub async fn create_custom_resource(
 
     // Run admission webhooks (mutating + validating) for custom resources
     // K8s runs webhooks for ALL resource types including CRDs
+    let cr_is_dry_run = crate::handlers::dryrun::is_dry_run(&params);
     {
         let gvk = rusternetes_common::admission::GroupVersionKind {
             group: group.clone(),
@@ -219,9 +220,9 @@ pub async fn create_custom_resource(
         };
         let cr_val = serde_json::to_value(&cr).ok();
         // Run mutating webhooks
-        let (_response, mutated_obj) = state
+        let (mutation_response, mutated_obj) = state
             .webhook_manager
-            .run_mutating_webhooks(
+            .run_mutating_webhooks_with_dryrun(
                 &rusternetes_common::admission::Operation::Create,
                 &gvk,
                 &gvr,
@@ -230,8 +231,16 @@ pub async fn create_custom_resource(
                 cr_val.clone(),
                 None,
                 &user_info,
+                cr_is_dry_run,
             )
             .await?;
+        // K8s mutating webhooks CAN deny — enforce the denial.
+        if let rusternetes_common::admission::AdmissionResponse::Deny(reason) = &mutation_response {
+            return Err(rusternetes_common::Error::Forbidden(format!(
+                "admission webhook denied the request: {}",
+                reason
+            )));
+        }
         if let Some(mutated) = mutated_obj {
             if let Ok(m) = serde_json::from_value::<CustomResource>(mutated) {
                 cr = m;
@@ -240,7 +249,7 @@ pub async fn create_custom_resource(
         // Run validating webhooks
         if let rusternetes_common::admission::AdmissionResponse::Deny(reason) = state
             .webhook_manager
-            .run_validating_webhooks(
+            .run_validating_webhooks_with_dryrun(
                 &rusternetes_common::admission::Operation::Create,
                 &gvk,
                 &gvr,
@@ -249,6 +258,7 @@ pub async fn create_custom_resource(
                 serde_json::to_value(&cr).ok(),
                 None,
                 &user_info,
+                cr_is_dry_run,
             )
             .await?
         {
@@ -266,7 +276,7 @@ pub async fn create_custom_resource(
     prune_custom_resource(&crd, &version, &mut cr);
 
     // Check for dry-run
-    if crate::handlers::dryrun::is_dry_run(&params) {
+    if cr_is_dry_run {
         return Ok((StatusCode::OK, Json(cr)));
     }
 
@@ -481,13 +491,11 @@ pub async fn update_custom_resource(
     cr.api_version = format!("{}/{}", group, version);
     cr.kind = crd.spec.names.kind.clone();
 
-    // Check for dry-run
-    if crate::handlers::dryrun::is_dry_run(&params) {
-        return Ok(Json(cr));
-    }
+    let cr_is_dry_run = crate::handlers::dryrun::is_dry_run(&params);
 
     // Run validating webhooks for UPDATE operations.
-    // K8s runs webhooks on all mutating operations (CREATE, UPDATE, DELETE).
+    // K8s runs webhooks on all mutating operations (CREATE, UPDATE, DELETE),
+    // and webhooks fire even for dry-run requests so deny decisions are honored.
     {
         use rusternetes_common::admission::{
             AdmissionResponse, GroupVersionKind, GroupVersionResource, Operation,
@@ -510,7 +518,7 @@ pub async fn update_custom_resource(
         let cr_value = serde_json::to_value(&cr).ok();
         if let AdmissionResponse::Deny(reason) = state
             .webhook_manager
-            .run_validating_webhooks(
+            .run_validating_webhooks_with_dryrun(
                 &Operation::Update,
                 &gvk,
                 &gvr,
@@ -519,11 +527,17 @@ pub async fn update_custom_resource(
                 cr_value,
                 None,
                 &user_info,
+                cr_is_dry_run,
             )
             .await?
         {
             return Err(rusternetes_common::Error::Forbidden(reason));
         }
+    }
+
+    // Skip persistence for dry-run after webhooks have run.
+    if cr_is_dry_run {
+        return Ok(Json(cr));
     }
 
     // Build storage key
@@ -1037,9 +1051,10 @@ pub async fn delete_custom_resource(
         let cr_value = serde_json::to_value(&cr).ok();
         // K8s DELETE AdmissionReview: object is nil, oldObject has the resource being deleted.
         // The webhook inspects oldObject to decide whether to allow deletion.
+        let is_dry_run = crate::handlers::dryrun::is_dry_run(&params);
         if let rusternetes_common::admission::AdmissionResponse::Deny(reason) = state
             .webhook_manager
-            .run_validating_webhooks(
+            .run_validating_webhooks_with_dryrun(
                 &rusternetes_common::admission::Operation::Delete,
                 &gvk,
                 &gvr,
@@ -1048,6 +1063,7 @@ pub async fn delete_custom_resource(
                 None,
                 cr_value,
                 &user_info,
+                is_dry_run,
             )
             .await?
         {
@@ -1134,6 +1150,17 @@ fn apply_schema_defaults(crd: &CustomResourceDefinition, version: &str, cr: &mut
     }
 }
 
+/// Test-only re-export of `prune_custom_resource` so admission webhook tests
+/// can verify the pruning path applied after mutating webhooks.
+#[cfg(test)]
+pub(crate) fn test_prune_custom_resource(
+    crd: &CustomResourceDefinition,
+    version: &str,
+    cr: &mut CustomResource,
+) {
+    prune_custom_resource(crd, version, cr)
+}
+
 /// Prune unknown fields from a CR based on the CRD schema.
 /// K8s removes fields not in the schema unless x-kubernetes-preserve-unknown-fields is set.
 /// This runs AFTER webhook mutation so webhook-added fields not in the schema are removed.
@@ -1182,11 +1209,26 @@ fn prune_custom_resource(crd: &CustomResourceDefinition, version: &str, cr: &mut
     }
 
     // Also prune within known fields like "data", "spec", "status"
-    // by checking their nested schema properties
+    // by checking their nested schema properties.
     if let Some(schema_props) = &schema.properties {
         for (field_name, field_schema) in schema_props {
             // Check if this field preserves unknown fields
             if field_schema.x_kubernetes_preserve_unknown_fields == Some(true) {
+                continue;
+            }
+            // The CustomResource type lifts "spec" and "status" out of the flat
+            // map and stores them on their own fields. Walk those as well so
+            // webhook-injected unknown fields under spec/status get pruned.
+            if field_name == "spec" {
+                if let Some(spec_val) = cr.spec.as_mut() {
+                    prune_value_against_schema(spec_val, field_schema, "spec");
+                }
+                continue;
+            }
+            if field_name == "status" {
+                if let Some(status_val) = cr.status.as_mut() {
+                    prune_value_against_schema(status_val, field_schema, "status");
+                }
                 continue;
             }
             if let Some(field_props) = &field_schema.properties {
@@ -1211,6 +1253,49 @@ fn prune_custom_resource(crd: &CustomResourceDefinition, version: &str, cr: &mut
                 }
             }
         }
+    }
+}
+
+/// Recursively prune unknown fields from a JSON value against a JSONSchema.
+/// Fields not declared as a property are removed unless the schema (or the
+/// enclosing object) carries x-kubernetes-preserve-unknown-fields.
+///
+/// K8s ref: staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning/prune.go
+fn prune_value_against_schema(
+    value: &mut serde_json::Value,
+    schema: &rusternetes_common::resources::JSONSchemaProps,
+    path: &str,
+) {
+    if schema.x_kubernetes_preserve_unknown_fields == Some(true) {
+        return;
+    }
+    match value {
+        serde_json::Value::Object(obj) => {
+            let Some(props) = schema.properties.as_ref() else {
+                return;
+            };
+            obj.retain(|k, _| {
+                let keep = props.contains_key(k);
+                if !keep {
+                    tracing::debug!("Pruning unknown field '{}.{}'", path, k);
+                }
+                keep
+            });
+            for (k, child_schema) in props {
+                if let Some(child_val) = obj.get_mut(k) {
+                    prune_value_against_schema(child_val, child_schema, &format!("{}.{}", path, k));
+                }
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            use rusternetes_common::resources::JSONSchemaPropsOrArray;
+            if let Some(JSONSchemaPropsOrArray::Schema(item_schema)) = schema.items.as_deref() {
+                for (i, item) in arr.iter_mut().enumerate() {
+                    prune_value_against_schema(item, item_schema, &format!("{}[{}]", path, i));
+                }
+            }
+        }
+        _ => {}
     }
 }
 

--- a/crates/api-server/src/handlers/pod.rs
+++ b/crates/api-server/src/handlers/pod.rs
@@ -259,7 +259,7 @@ pub async fn create(
 
     let (mutation_response, mutated_pod_value) = state
         .webhook_manager
-        .run_mutating_webhooks(
+        .run_mutating_webhooks_with_dryrun(
             &Operation::Create,
             &gvk,
             &gvr,
@@ -268,6 +268,7 @@ pub async fn create(
             Some(pod_value),
             None,
             &user_info,
+            is_dry_run,
         )
         .await?;
 
@@ -452,7 +453,7 @@ pub async fn create(
 
     let validation_response = state
         .webhook_manager
-        .run_validating_webhooks(
+        .run_validating_webhooks_with_dryrun(
             &Operation::Create,
             &gvk,
             &gvr,
@@ -461,6 +462,7 @@ pub async fn create(
             Some(final_pod_value),
             None,
             &user_info,
+            is_dry_run,
         )
         .await?;
 
@@ -692,7 +694,7 @@ pub async fn update(
 
     let (mutation_response, mutated_pod_value) = state
         .webhook_manager
-        .run_mutating_webhooks(
+        .run_mutating_webhooks_with_dryrun(
             &Operation::Update,
             &gvk,
             &gvr,
@@ -701,6 +703,7 @@ pub async fn update(
             Some(pod_value),
             Some(old_pod_value.clone()),
             &user_info,
+            is_dry_run,
         )
         .await?;
 
@@ -726,7 +729,7 @@ pub async fn update(
 
     let validation_response = state
         .webhook_manager
-        .run_validating_webhooks(
+        .run_validating_webhooks_with_dryrun(
             &Operation::Update,
             &gvk,
             &gvr,
@@ -735,6 +738,7 @@ pub async fn update(
             Some(final_pod_value),
             Some(old_pod_value.clone()),
             &user_info,
+            is_dry_run,
         )
         .await?;
 

--- a/crates/api-server/tests/admission_webhook_e2e_test.rs
+++ b/crates/api-server/tests/admission_webhook_e2e_test.rs
@@ -16,9 +16,9 @@ use rusternetes_common::{
         GroupVersionResource, Operation, PatchOp, PatchOperation, UserInfo,
     },
     resources::{
-        FailurePolicy, MutatingWebhook, MutatingWebhookConfiguration, OperationType, Rule,
-        RuleWithOperations, SideEffectClass, ValidatingWebhook, ValidatingWebhookConfiguration,
-        WebhookClientConfig,
+        FailurePolicy, MutatingWebhook, MutatingWebhookConfiguration, OperationType,
+        ReinvocationPolicy, Rule, RuleWithOperations, SideEffectClass, ValidatingWebhook,
+        ValidatingWebhookConfiguration, WebhookClientConfig,
     },
     types::ObjectMeta,
 };
@@ -185,6 +185,121 @@ async fn start_mock_mutating_server(
 
     let url = format!("http://{}", addr);
     (url, shutdown_tx)
+}
+
+/// Start a mock validating webhook server that sleeps longer than the request
+/// timeout. Used to verify timeoutSeconds enforcement.
+async fn start_mock_slow_validating_server(
+    delay: std::time::Duration,
+) -> (String, oneshot::Sender<()>) {
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+    let route =
+        warp::post()
+            .and(warp::body::json())
+            .and_then(move |review: AdmissionReview| async move {
+                tokio::time::sleep(delay).await;
+                let response = if let Some(request) = review.request {
+                    AdmissionReviewResponse::allow(request.uid)
+                } else {
+                    AdmissionReviewResponse {
+                        uid: "unknown".to_string(),
+                        allowed: true,
+                        status: None,
+                        patch: None,
+                        patch_type: None,
+                        audit_annotations: None,
+                        warnings: None,
+                    }
+                };
+                let response_review = AdmissionReview {
+                    api_version: "admission.k8s.io/v1".to_string(),
+                    kind: "AdmissionReview".to_string(),
+                    request: None,
+                    response: Some(response),
+                };
+                Ok::<_, warp::Rejection>(warp::reply::json(&response_review))
+            });
+
+    let (addr, server) =
+        warp::serve(route).bind_with_graceful_shutdown(([127, 0, 0, 1], 0), async {
+            shutdown_rx.await.ok();
+        });
+
+    tokio::spawn(server);
+
+    let url = format!("http://{}", addr);
+    (url, shutdown_tx)
+}
+
+/// Start a mock mutating webhook server whose label value reflects the call
+/// count. Used to verify reinvocation: the second invocation returns a
+/// different value than the first.
+async fn start_mock_counting_mutating_server(
+    label_key: String,
+) -> (
+    String,
+    oneshot::Sender<()>,
+    Arc<std::sync::atomic::AtomicU32>,
+) {
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let counter = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let counter_clone = counter.clone();
+
+    let route = warp::post()
+        .and(warp::body::json())
+        .map(move |review: AdmissionReview| {
+            let call = counter_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+            let label_value = format!("call-{}", call);
+            let response = if let Some(request) = review.request {
+                let patch = vec![PatchOperation {
+                    op: PatchOp::Add,
+                    path: format!("/metadata/labels/{}", label_key),
+                    value: Some(json!(label_value)),
+                    from: None,
+                }];
+                use base64::Engine;
+                let patch_json = serde_json::to_string(&patch).unwrap();
+                let patch_base64 =
+                    base64::engine::general_purpose::STANDARD.encode(patch_json.as_bytes());
+                AdmissionReviewResponse {
+                    uid: request.uid,
+                    allowed: true,
+                    status: None,
+                    patch: Some(patch_base64),
+                    patch_type: Some("JSONPatch".to_string()),
+                    audit_annotations: None,
+                    warnings: None,
+                }
+            } else {
+                AdmissionReviewResponse {
+                    uid: "unknown".to_string(),
+                    allowed: true,
+                    status: None,
+                    patch: None,
+                    patch_type: None,
+                    audit_annotations: None,
+                    warnings: None,
+                }
+            };
+            let response_review = AdmissionReview {
+                api_version: "admission.k8s.io/v1".to_string(),
+                kind: "AdmissionReview".to_string(),
+                request: None,
+                response: Some(response),
+            };
+            warp::reply::json(&response_review)
+        });
+
+    let (addr, server) =
+        warp::serve(route).bind_with_graceful_shutdown(([127, 0, 0, 1], 0), async {
+            shutdown_rx.await.ok();
+        });
+
+    tokio::spawn(server);
+
+    let url = format!("http://{}", addr);
+    (url, shutdown_tx, counter)
 }
 
 // ===== Webhook Client Tests =====
@@ -711,4 +826,508 @@ async fn test_webhook_manager_denial_stops_request() {
             panic!("Unexpected response type");
         }
     }
+}
+
+// ===== Timeout & Reinvocation Tests =====
+
+/// A webhook that sleeps longer than `timeoutSeconds` must be aborted at the
+/// deadline. With FailurePolicy=Fail the request fails.
+#[tokio::test]
+async fn test_webhook_timeout_fail_policy_aborts_at_deadline() {
+    // Server sleeps 5s, webhook timeout is 1s.
+    let (url, _shutdown) =
+        start_mock_slow_validating_server(std::time::Duration::from_secs(5)).await;
+
+    let client = AdmissionWebhookClient::new();
+    let webhook = ValidatingWebhook {
+        name: "slow-validator".to_string(),
+        client_config: WebhookClientConfig {
+            url: Some(url),
+            service: None,
+            ca_bundle: None,
+        },
+        rules: vec![],
+        failure_policy: Some(FailurePolicy::Fail),
+        match_policy: None,
+        namespace_selector: None,
+        object_selector: None,
+        side_effects: SideEffectClass::None,
+        timeout_seconds: Some(1),
+        admission_review_versions: vec!["v1".to_string()],
+        match_conditions: None,
+    };
+
+    let request = AdmissionReviewRequest {
+        uid: "timeout-uid".to_string(),
+        kind: GroupVersionKind {
+            group: "".to_string(),
+            version: "v1".to_string(),
+            kind: "Pod".to_string(),
+        },
+        resource: GroupVersionResource {
+            group: "".to_string(),
+            version: "v1".to_string(),
+            resource: "pods".to_string(),
+        },
+        sub_resource: None,
+        request_kind: None,
+        request_resource: None,
+        request_sub_resource: None,
+        name: "slow-pod".to_string(),
+        namespace: Some("default".to_string()),
+        operation: Operation::Create,
+        user_info: UserInfo {
+            username: "admin".to_string(),
+            uid: "admin-uid".to_string(),
+            groups: vec!["system:masters".to_string()],
+        },
+        object: Some(json!({"metadata": {"name": "slow-pod"}})),
+        old_object: None,
+        dry_run: None,
+        options: None,
+    };
+
+    let start = std::time::Instant::now();
+    let result = client.call_validating_webhook(&webhook, &request).await;
+    let elapsed = start.elapsed();
+
+    assert!(
+        result.is_err(),
+        "Expected timeout error with FailurePolicy=Fail, got {:?}",
+        result
+    );
+    // Total call time must be bounded near the 1s timeout, not the 5s sleep.
+    // Allow 3s slack for CI flakiness while still proving the deadline aborted.
+    assert!(
+        elapsed < std::time::Duration::from_secs(3),
+        "Webhook call exceeded deadline: {:?}",
+        elapsed
+    );
+    let msg = format!("{}", result.unwrap_err()).to_lowercase();
+    assert!(
+        msg.contains("deadline") || msg.contains("timeout") || msg.contains("timed out"),
+        "Expected deadline/timeout message, got: {}",
+        msg
+    );
+}
+
+/// With FailurePolicy=Ignore, a slow webhook must not block the request once
+/// the deadline elapses.
+#[tokio::test]
+async fn test_webhook_timeout_ignore_policy_allows_request() {
+    let (url, _shutdown) =
+        start_mock_slow_validating_server(std::time::Duration::from_secs(5)).await;
+
+    let client = AdmissionWebhookClient::new();
+    let webhook = ValidatingWebhook {
+        name: "slow-validator-ignore".to_string(),
+        client_config: WebhookClientConfig {
+            url: Some(url),
+            service: None,
+            ca_bundle: None,
+        },
+        rules: vec![],
+        failure_policy: Some(FailurePolicy::Ignore),
+        match_policy: None,
+        namespace_selector: None,
+        object_selector: None,
+        side_effects: SideEffectClass::None,
+        timeout_seconds: Some(1),
+        admission_review_versions: vec!["v1".to_string()],
+        match_conditions: None,
+    };
+
+    let request = AdmissionReviewRequest {
+        uid: "timeout-ignore-uid".to_string(),
+        kind: GroupVersionKind {
+            group: "".to_string(),
+            version: "v1".to_string(),
+            kind: "Pod".to_string(),
+        },
+        resource: GroupVersionResource {
+            group: "".to_string(),
+            version: "v1".to_string(),
+            resource: "pods".to_string(),
+        },
+        sub_resource: None,
+        request_kind: None,
+        request_resource: None,
+        request_sub_resource: None,
+        name: "slow-pod".to_string(),
+        namespace: Some("default".to_string()),
+        operation: Operation::Create,
+        user_info: UserInfo {
+            username: "admin".to_string(),
+            uid: "admin-uid".to_string(),
+            groups: vec!["system:masters".to_string()],
+        },
+        object: Some(json!({"metadata": {"name": "slow-pod"}})),
+        old_object: None,
+        dry_run: None,
+        options: None,
+    };
+
+    let start = std::time::Instant::now();
+    let response = client
+        .call_validating_webhook(&webhook, &request)
+        .await
+        .expect("Ignore policy must not propagate error");
+    let elapsed = start.elapsed();
+
+    assert!(response.allowed, "FailurePolicy=Ignore must allow request");
+    assert!(
+        elapsed < std::time::Duration::from_secs(3),
+        "Webhook call exceeded deadline: {:?}",
+        elapsed
+    );
+}
+
+/// reinvocationPolicy=IfNeeded triggers when a later mutating webhook changes
+/// the object after this webhook's first call.
+///
+/// Both A and B have IfNeeded policy. MemoryStorage iterates as a HashMap, so
+/// the order in which the two webhooks fire is non-deterministic; whichever
+/// runs first must be reinvoked after the other mutates the object. We verify
+/// the order-independent invariant: one of {A, B} is called twice and the
+/// other is called once.
+#[tokio::test]
+async fn test_mutating_webhook_reinvocation_if_needed_triggers_when_changed() {
+    let storage = Arc::new(MemoryStorage::new());
+    let manager = AdmissionWebhookManager::new(storage.clone());
+
+    let (url_a, _shutdown_a, counter_a) =
+        start_mock_counting_mutating_server("a".to_string()).await;
+    let (url_b, _shutdown_b, counter_b) =
+        start_mock_counting_mutating_server("b".to_string()).await;
+
+    let mk_webhook = |name: &str, url: String| MutatingWebhook {
+        name: name.to_string(),
+        client_config: WebhookClientConfig {
+            url: Some(url),
+            service: None,
+            ca_bundle: None,
+        },
+        rules: vec![RuleWithOperations {
+            operations: vec![OperationType::Create],
+            rule: Rule {
+                api_groups: vec!["".to_string()],
+                api_versions: vec!["v1".to_string()],
+                resources: vec!["pods".to_string()],
+                scope: None,
+            },
+        }],
+        failure_policy: None,
+        match_policy: None,
+        namespace_selector: None,
+        object_selector: None,
+        side_effects: SideEffectClass::None,
+        timeout_seconds: None,
+        admission_review_versions: vec!["v1".to_string()],
+        reinvocation_policy: Some(ReinvocationPolicy::IfNeeded),
+        match_conditions: None,
+    };
+
+    let config_a = MutatingWebhookConfiguration {
+        api_version: "admissionregistration.k8s.io/v1".to_string(),
+        kind: "MutatingWebhookConfiguration".to_string(),
+        metadata: ObjectMeta::new("a-mutating"),
+        webhooks: Some(vec![mk_webhook("a-mutator", url_a)]),
+    };
+    let config_b = MutatingWebhookConfiguration {
+        api_version: "admissionregistration.k8s.io/v1".to_string(),
+        kind: "MutatingWebhookConfiguration".to_string(),
+        metadata: ObjectMeta::new("b-mutating"),
+        webhooks: Some(vec![mk_webhook("b-mutator", url_b)]),
+    };
+
+    storage
+        .create(
+            &build_key("mutatingwebhookconfigurations", None, "a-mutating"),
+            &config_a,
+        )
+        .await
+        .unwrap();
+    storage
+        .create(
+            &build_key("mutatingwebhookconfigurations", None, "b-mutating"),
+            &config_b,
+        )
+        .await
+        .unwrap();
+
+    let object = Some(json!({"metadata": {"name": "rein-pod", "labels": {}}}));
+    let (_response, mutated) = manager
+        .run_mutating_webhooks(
+            &Operation::Create,
+            &GroupVersionKind {
+                group: "".to_string(),
+                version: "v1".to_string(),
+                kind: "Pod".to_string(),
+            },
+            &GroupVersionResource {
+                group: "".to_string(),
+                version: "v1".to_string(),
+                resource: "pods".to_string(),
+            },
+            Some("default"),
+            "rein-pod",
+            object,
+            None,
+            &UserInfo {
+                username: "admin".to_string(),
+                uid: "admin-uid".to_string(),
+                groups: vec!["system:masters".to_string()],
+            },
+        )
+        .await
+        .unwrap();
+
+    let a_calls = counter_a.load(std::sync::atomic::Ordering::SeqCst);
+    let b_calls = counter_b.load(std::sync::atomic::Ordering::SeqCst);
+
+    // Both A and B have IfNeeded and both mutated the object. After the first
+    // pass each one's snapshot diverges from the final object (because the
+    // other added a label after it), so both are reinvoked. K8s bounds
+    // reinvocation to one extra round per webhook, so each is called at most
+    // twice.
+    // K8s ref: staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
+    assert!(
+        a_calls >= 1 && b_calls >= 1,
+        "Both webhooks must run at least once (a={}, b={})",
+        a_calls,
+        b_calls
+    );
+    assert!(
+        a_calls <= 2 && b_calls <= 2,
+        "Each webhook must be reinvoked at most once (a={}, b={})",
+        a_calls,
+        b_calls
+    );
+    // At least one webhook must have been reinvoked — both mutated the object,
+    // so the webhook that ran first must see the second one's change.
+    assert!(
+        a_calls + b_calls >= 3,
+        "Expected at least one reinvocation (a={}, b={})",
+        a_calls,
+        b_calls
+    );
+
+    // Final object must carry both labels. The webhook(s) reinvoked have
+    // call-2; any not reinvoked stays at call-1.
+    let obj = mutated.expect("object should exist");
+    let label_a = obj["metadata"]["labels"]["a"].as_str().unwrap_or("");
+    let label_b = obj["metadata"]["labels"]["b"].as_str().unwrap_or("");
+    let expected_a = if a_calls == 2 { "call-2" } else { "call-1" };
+    let expected_b = if b_calls == 2 { "call-2" } else { "call-1" };
+    assert_eq!(label_a, expected_a, "label A mismatch");
+    assert_eq!(label_b, expected_b, "label B mismatch");
+}
+
+/// reinvocationPolicy=IfNeeded must NOT trigger when no later webhook mutates
+/// the object after this webhook's call.
+#[tokio::test]
+async fn test_mutating_webhook_reinvocation_if_needed_skipped_when_unchanged() {
+    let storage = Arc::new(MemoryStorage::new());
+    let manager = AdmissionWebhookManager::new(storage.clone());
+
+    let (url, _shutdown, counter) = start_mock_counting_mutating_server("a".to_string()).await;
+
+    let config = MutatingWebhookConfiguration {
+        api_version: "admissionregistration.k8s.io/v1".to_string(),
+        kind: "MutatingWebhookConfiguration".to_string(),
+        metadata: ObjectMeta::new("lone-mutating"),
+        webhooks: Some(vec![MutatingWebhook {
+            name: "lone-mutator".to_string(),
+            client_config: WebhookClientConfig {
+                url: Some(url),
+                service: None,
+                ca_bundle: None,
+            },
+            rules: vec![RuleWithOperations {
+                operations: vec![OperationType::Create],
+                rule: Rule {
+                    api_groups: vec!["".to_string()],
+                    api_versions: vec!["v1".to_string()],
+                    resources: vec!["pods".to_string()],
+                    scope: None,
+                },
+            }],
+            failure_policy: None,
+            match_policy: None,
+            namespace_selector: None,
+            object_selector: None,
+            side_effects: SideEffectClass::None,
+            timeout_seconds: None,
+            admission_review_versions: vec!["v1".to_string()],
+            reinvocation_policy: Some(ReinvocationPolicy::IfNeeded),
+            match_conditions: None,
+        }]),
+    };
+
+    storage
+        .create(
+            &build_key("mutatingwebhookconfigurations", None, "lone-mutating"),
+            &config,
+        )
+        .await
+        .unwrap();
+
+    let object = Some(json!({"metadata": {"name": "lone-pod", "labels": {}}}));
+    manager
+        .run_mutating_webhooks(
+            &Operation::Create,
+            &GroupVersionKind {
+                group: "".to_string(),
+                version: "v1".to_string(),
+                kind: "Pod".to_string(),
+            },
+            &GroupVersionResource {
+                group: "".to_string(),
+                version: "v1".to_string(),
+                resource: "pods".to_string(),
+            },
+            Some("default"),
+            "lone-pod",
+            object,
+            None,
+            &UserInfo {
+                username: "admin".to_string(),
+                uid: "admin-uid".to_string(),
+                groups: vec!["system:masters".to_string()],
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        counter.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "Webhook must be called exactly once when nothing else mutates"
+    );
+}
+
+/// reinvocationPolicy=Never (default) must never reinvoke.
+#[tokio::test]
+async fn test_mutating_webhook_reinvocation_never_does_not_reinvoke() {
+    let storage = Arc::new(MemoryStorage::new());
+    let manager = AdmissionWebhookManager::new(storage.clone());
+
+    let (url_a, _shutdown_a, counter_a) =
+        start_mock_counting_mutating_server("a".to_string()).await;
+    let (url_b, _shutdown_b) =
+        start_mock_mutating_server("b".to_string(), "from-b".to_string()).await;
+
+    let config_a = MutatingWebhookConfiguration {
+        api_version: "admissionregistration.k8s.io/v1".to_string(),
+        kind: "MutatingWebhookConfiguration".to_string(),
+        metadata: ObjectMeta::new("a-never-mutating"),
+        webhooks: Some(vec![MutatingWebhook {
+            name: "a-never-mutator".to_string(),
+            client_config: WebhookClientConfig {
+                url: Some(url_a),
+                service: None,
+                ca_bundle: None,
+            },
+            rules: vec![RuleWithOperations {
+                operations: vec![OperationType::Create],
+                rule: Rule {
+                    api_groups: vec!["".to_string()],
+                    api_versions: vec!["v1".to_string()],
+                    resources: vec!["pods".to_string()],
+                    scope: None,
+                },
+            }],
+            failure_policy: None,
+            match_policy: None,
+            namespace_selector: None,
+            object_selector: None,
+            side_effects: SideEffectClass::None,
+            timeout_seconds: None,
+            admission_review_versions: vec!["v1".to_string()],
+            reinvocation_policy: Some(ReinvocationPolicy::Never),
+            match_conditions: None,
+        }]),
+    };
+    let config_b = MutatingWebhookConfiguration {
+        api_version: "admissionregistration.k8s.io/v1".to_string(),
+        kind: "MutatingWebhookConfiguration".to_string(),
+        metadata: ObjectMeta::new("b-never-mutating"),
+        webhooks: Some(vec![MutatingWebhook {
+            name: "b-never-mutator".to_string(),
+            client_config: WebhookClientConfig {
+                url: Some(url_b),
+                service: None,
+                ca_bundle: None,
+            },
+            rules: vec![RuleWithOperations {
+                operations: vec![OperationType::Create],
+                rule: Rule {
+                    api_groups: vec!["".to_string()],
+                    api_versions: vec!["v1".to_string()],
+                    resources: vec!["pods".to_string()],
+                    scope: None,
+                },
+            }],
+            failure_policy: None,
+            match_policy: None,
+            namespace_selector: None,
+            object_selector: None,
+            side_effects: SideEffectClass::None,
+            timeout_seconds: None,
+            admission_review_versions: vec!["v1".to_string()],
+            reinvocation_policy: None,
+            match_conditions: None,
+        }]),
+    };
+
+    storage
+        .create(
+            &build_key("mutatingwebhookconfigurations", None, "a-never-mutating"),
+            &config_a,
+        )
+        .await
+        .unwrap();
+    storage
+        .create(
+            &build_key("mutatingwebhookconfigurations", None, "b-never-mutating"),
+            &config_b,
+        )
+        .await
+        .unwrap();
+
+    let object = Some(json!({"metadata": {"name": "rein-never-pod", "labels": {}}}));
+    let (_response, mutated) = manager
+        .run_mutating_webhooks(
+            &Operation::Create,
+            &GroupVersionKind {
+                group: "".to_string(),
+                version: "v1".to_string(),
+                kind: "Pod".to_string(),
+            },
+            &GroupVersionResource {
+                group: "".to_string(),
+                version: "v1".to_string(),
+                resource: "pods".to_string(),
+            },
+            Some("default"),
+            "rein-never-pod",
+            object,
+            None,
+            &UserInfo {
+                username: "admin".to_string(),
+                uid: "admin-uid".to_string(),
+                groups: vec!["system:masters".to_string()],
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        counter_a.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "A with reinvocationPolicy=Never must NOT be reinvoked"
+    );
+    let obj = mutated.expect("object should exist");
+    assert_eq!(obj["metadata"]["labels"]["a"], json!("call-1"));
+    assert_eq!(obj["metadata"]["labels"]["b"], json!("from-b"));
 }

--- a/crates/common/src/cel.rs
+++ b/crates/common/src/cel.rs
@@ -49,7 +49,7 @@ impl CELEvaluator {
 
         // Add variables to context
         for (key, value) in &context.variables {
-            cel_context.add_variable(key.clone(), value.clone());
+            let _ = cel_context.add_variable(key.clone(), value.clone());
         }
 
         // Execute the program
@@ -84,7 +84,7 @@ impl CELEvaluator {
 
         // Add variables to context
         for (key, value) in &context.variables {
-            cel_context.add_variable(key.clone(), value.clone());
+            let _ = cel_context.add_variable(key.clone(), value.clone());
         }
 
         // Execute the program
@@ -116,7 +116,7 @@ impl CELEvaluator {
 
         let mut cel_context = Context::default();
         for (key, value) in &context.variables {
-            cel_context.add_variable(key.clone(), value.clone());
+            let _ = cel_context.add_variable(key.clone(), value.clone());
         }
 
         program


### PR DESCRIPTION
## Changes

Two admission webhook policy gaps surfaced by conformance.

### \`feat(admission): enforce sideEffects for dry-run + deny propagation for subresources\`

- **sideEffects gate for dry-run**: When the incoming request is dry-run, webhooks declaring \`sideEffects: Some\` or \`Unknown\` are skipped — only \`None\` or \`NoneOnDryRun\` are called. K8s requires this so dry-run is truly side-effect-free.
- **Deny propagation across subresources**: A webhook deny on the parent resource now also denies the matching subresource request (\`status\`, \`scale\`, etc.) and vice versa, mirroring the K8s contract that a single AdmissionRequest covers all subresources of one object.

### \`feat: enforce webhook timeout and IfNeeded reinvocation policy\`

- **timeoutSeconds**: We were calling webhooks with no per-call deadline. Now \`webhook.timeoutSeconds\` (default 10) bounds each invocation via \`tokio::time::timeout\`. If the webhook is \`failurePolicy: Fail\` the timeout is treated as a deny; if \`Ignore\`, it's skipped.
- **reinvocationPolicy: IfNeeded**: Mutating webhooks that mutated the object trigger a second pass through the webhook chain so later webhooks see the first round's output. Mirrors the K8s \`IfNeeded\` semantics.

## Verification

\`cargo build --workspace --locked\` clean. Depends on #32 for green CI.