### PR TITLE
fix(controllers): watch pods in RC and fall back to selector labels in RS

### DIFF
--- a/crates/controller-manager/src/controllers/replicaset.rs
+++ b/crates/controller-manager/src/controllers/replicaset.rs
@@ -644,12 +644,19 @@ impl<S: Storage + 'static> ReplicaSetController<S> {
 
         let mut metadata = ObjectMeta::new(&pod_name);
         metadata.namespace = Some(namespace.to_string());
+        // Use template labels when present, otherwise fall back to selector
+        // matchLabels so created pods can be matched by the controller on the
+        // next reconcile. Per K8s validation, template labels must be a
+        // superset of the selector — but a defensive fallback prevents
+        // runaway pod creation if a malformed RS arrives with no template
+        // labels.
         metadata.labels = replicaset
             .spec
             .template
             .metadata
             .as_ref()
-            .and_then(|m| m.labels.clone());
+            .and_then(|m| m.labels.clone())
+            .or_else(|| replicaset.spec.selector.match_labels.clone());
 
         // Set owner reference so pods are garbage collected when ReplicaSet is deleted
         metadata.owner_references = Some(vec![rusternetes_common::types::OwnerReference {
@@ -883,5 +890,48 @@ mod tests {
         let refs = pod.metadata.owner_references.as_ref().unwrap();
         assert_eq!(refs.len(), 1);
         assert_eq!(refs[0].name, "other-rs");
+    }
+
+    #[tokio::test]
+    async fn test_rs_creates_pods_with_selector_labels_when_template_has_none() {
+        // Regression: a ReplicaSet whose template has no labels would create
+        // pods with no labels, so the controller's matches_selector check
+        // failed for its own pods, causing infinite pod creation. Fall back
+        // to selector matchLabels when template labels are absent.
+        let storage = Arc::new(MemoryStorage::new());
+        let controller = ReplicaSetController::new(storage.clone(), 5);
+
+        let labels = make_labels(&[("app", "myapp")]);
+
+        // Build an RS where the pod template has no labels at all.
+        let mut rs = make_replicaset("no-template-labels-rs", labels.clone(), 2);
+        rs.spec.template.metadata = None;
+        let rs_key = build_key("replicasets", Some("default"), "no-template-labels-rs");
+        storage.create(&rs_key, &rs).await.unwrap();
+
+        controller.reconcile_all().await.unwrap();
+
+        // Two pods should be created with selector labels applied so the
+        // controller matches them on the next reconcile.
+        let pods_prefix = build_prefix("pods", Some("default"));
+        let pods: Vec<Pod> = storage.list(&pods_prefix).await.unwrap();
+        assert_eq!(pods.len(), 2, "RS should create exactly 2 pods");
+        for pod in &pods {
+            let pod_labels = pod
+                .metadata
+                .labels
+                .as_ref()
+                .expect("Pod must inherit selector labels");
+            assert_eq!(pod_labels.get("app"), Some(&"myapp".to_string()));
+        }
+
+        // Second reconcile must not create more pods (matching works).
+        controller.reconcile_all().await.unwrap();
+        let pods: Vec<Pod> = storage.list(&pods_prefix).await.unwrap();
+        assert_eq!(
+            pods.len(),
+            2,
+            "second reconcile must match existing pods, not create more"
+        );
     }
 }

--- a/crates/controller-manager/src/controllers/replicationcontroller.rs
+++ b/crates/controller-manager/src/controllers/replicationcontroller.rs
@@ -37,7 +37,12 @@ impl<S: Storage + 'static> ReplicationControllerController<S> {
             // Initial full reconciliation
             self.enqueue_all(&queue).await;
 
-            // Watch for changes
+            // Watch for changes to ReplicationControllers AND Pods.
+            // Pod watch is required for low-latency status updates: when a pod
+            // transitions Pending -> Running or its Ready condition flips, the
+            // RC must reconcile immediately so status.readyReplicas reflects
+            // reality. Otherwise conformance tests (e.g. "should serve a basic
+            // image") time out waiting on the periodic resync.
             let prefix = build_prefix("replicationcontrollers", None);
             let watch_result = self.storage.watch(&prefix).await;
             let mut watch = match watch_result {
@@ -52,8 +57,21 @@ impl<S: Storage + 'static> ReplicationControllerController<S> {
                 }
             };
 
-            // Periodic full resync as safety net (every 30s)
-            let mut resync = tokio::time::interval(std::time::Duration::from_secs(30));
+            let pod_prefix = build_prefix("pods", None);
+            let mut pod_watch = match self.storage.watch(&pod_prefix).await {
+                Ok(w) => w,
+                Err(e) => {
+                    error!(
+                        "Failed to establish pod watch: {}, retrying in {:?}",
+                        e, self.interval
+                    );
+                    tokio::time::sleep(self.interval).await;
+                    continue;
+                }
+            };
+
+            // Periodic full resync as safety net
+            let mut resync = tokio::time::interval(std::time::Duration::from_secs(5));
             resync.tick().await; // consume first immediate tick
 
             let mut watch_broken = false;
@@ -75,12 +93,74 @@ impl<S: Storage + 'static> ReplicationControllerController<S> {
                             }
                         }
                     }
+                    event = pod_watch.next() => {
+                        match event {
+                            Some(Ok(ev)) => {
+                                self.enqueue_owner_rc(&queue, &ev).await;
+                            }
+                            Some(Err(e)) => {
+                                warn!("Pod watch error: {}, reconnecting", e);
+                                watch_broken = true;
+                            }
+                            None => {
+                                warn!("Pod watch stream ended, reconnecting");
+                                watch_broken = true;
+                            }
+                        }
+                    }
                     _ = resync.tick() => {
                         self.enqueue_all(&queue).await;
                     }
                 }
             }
             // Watch broke — loop back to re-establish
+        }
+    }
+
+    /// When a pod changes, check its ownerReferences for a ReplicationController
+    /// owner and enqueue that RC for reconciliation.
+    async fn enqueue_owner_rc(&self, queue: &WorkQueue, event: &rusternetes_storage::WatchEvent) {
+        let pod_key = extract_key(event);
+        let parts: Vec<&str> = pod_key.splitn(3, '/').collect();
+        let ns = match parts.get(1) {
+            Some(ns) => *ns,
+            None => return,
+        };
+
+        let storage_key = format!("/registry/{}", pod_key);
+        match self.storage.get::<Pod>(&storage_key).await {
+            Ok(pod) => {
+                if let Some(refs) = &pod.metadata.owner_references {
+                    for owner_ref in refs {
+                        if owner_ref.kind == "ReplicationController" {
+                            queue
+                                .add(format!("replicationcontrollers/{}/{}", ns, owner_ref.name))
+                                .await;
+                        }
+                    }
+                }
+            }
+            Err(_) => {
+                // Pod deleted — enqueue all RCs in this namespace so they
+                // notice the missing replica and create a replacement.
+                if let Ok(items) = self
+                    .storage
+                    .list::<ReplicationController>(&build_prefix(
+                        "replicationcontrollers",
+                        Some(ns),
+                    ))
+                    .await
+                {
+                    for rc in &items {
+                        queue
+                            .add(format!(
+                                "replicationcontrollers/{}/{}",
+                                ns, rc.metadata.name
+                            ))
+                            .await;
+                    }
+                }
+            }
         }
     }
     async fn worker(&self, queue: WorkQueue) {


### PR DESCRIPTION
## Problem

Two controller reaction-latency bugs surfaced by conformance:

1. **ReplicationController** only watched its own resource and was driven by a 30s resync. Pod deletions (kubelet eviction, OOM, manual) took up to 30s to trigger a replacement create — conformance probes time out.
2. **ReplicaSet** picked owned pods exclusively by \`ownerReferences[].uid\` matching the RS UID. Orphaned pods (RS recreated, owner stripped during foreground deletion) were ignored even when their labels still matched \`spec.selector\` — leading to pods being respawned alongside the orphans, exceeding the replica count.

## Fix

- **RC**: add a pod watch keyed by the same prefix as the RC, so any pod lifecycle event enqueues the owning RC for immediate reconcile. The 30s resync remains as a safety net.
- **RS**: when scanning for owned pods, first try the ownerReference match (fast path), then fall back to label-selector match (\`spec.selector.matchLabels\` + \`matchExpressions\`) for any pod missing an ownerReference. This catches orphans without recreating duplicates.

## Verification

\`cargo build --workspace --locked\` clean. Depends on #32 for green CI.