### PR TITLE
fix(common): tolerate integer/float in Quantity HashMap decode

### DIFF
--- a/crates/common/src/resources/node.rs
+++ b/crates/common/src/resources/node.rs
@@ -71,10 +71,18 @@ pub struct Taint {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NodeStatus {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::types::deserialize_quantity_map"
+    )]
     pub capacity: Option<HashMap<String, String>>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::types::deserialize_quantity_map"
+    )]
     pub allocatable: Option<HashMap<String, String>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/common/src/resources/pod.rs
+++ b/crates/common/src/resources/pod.rs
@@ -140,7 +140,11 @@ pub struct PodSpec {
     pub topology_spread_constraints: Option<Vec<TopologySpreadConstraint>>,
 
     /// Overhead represents the resource overhead associated with running a pod
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::types::deserialize_quantity_map"
+    )]
     pub overhead: Option<HashMap<String, String>>,
 
     /// SchedulerName is the name of the scheduler to be used to schedule this pod
@@ -1294,7 +1298,11 @@ pub struct ContainerStatus {
     pub started: Option<bool>,
 
     /// Resources allocated to this container by the node
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::types::deserialize_quantity_map"
+    )]
     pub allocated_resources: Option<HashMap<String, String>>,
 
     /// Detailed status of allocated resources for this container

--- a/crates/common/src/resources/policy.rs
+++ b/crates/common/src/resources/policy.rs
@@ -41,7 +41,11 @@ impl ResourceQuota {
 #[serde(rename_all = "camelCase")]
 pub struct ResourceQuotaSpec {
     /// Hard is the set of desired hard limits for each named resource
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::types::deserialize_quantity_map"
+    )]
     pub hard: Option<HashMap<String, String>>,
 
     /// A collection of filters that must match each object tracked by a quota
@@ -81,11 +85,19 @@ pub struct ScopedResourceSelectorRequirement {
 #[serde(rename_all = "camelCase")]
 pub struct ResourceQuotaStatus {
     /// Hard is the set of enforced hard limits for each named resource
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::types::deserialize_quantity_map"
+    )]
     pub hard: Option<HashMap<String, String>>,
 
     /// Used is the current observed total usage of the resource in the namespace
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::types::deserialize_quantity_map"
+    )]
     pub used: Option<HashMap<String, String>>,
 }
 
@@ -136,23 +148,43 @@ pub struct LimitRangeItem {
     pub item_type: String,
 
     /// Max usage constraints on this kind by resource name
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::types::deserialize_quantity_map"
+    )]
     pub max: Option<HashMap<String, String>>,
 
     /// Min usage constraints on this kind by resource name
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::types::deserialize_quantity_map"
+    )]
     pub min: Option<HashMap<String, String>>,
 
     /// Default resource requirement limit value by resource name if not specified
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::types::deserialize_quantity_map"
+    )]
     pub default: Option<HashMap<String, String>>,
 
     /// DefaultRequest is the default resource requirement request value by resource name if not specified
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::types::deserialize_quantity_map"
+    )]
     pub default_request: Option<HashMap<String, String>>,
 
     /// MaxLimitRequestRatio represents the max burst value for the named resource
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::types::deserialize_quantity_map"
+    )]
     pub max_limit_request_ratio: Option<HashMap<String, String>>,
 }
 

--- a/crates/common/src/resources/volume.rs
+++ b/crates/common/src/resources/volume.rs
@@ -263,9 +263,17 @@ pub struct PersistentVolumeClaimSpec {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ResourceRequirements {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::types::deserialize_quantity_map"
+    )]
     pub limits: Option<HashMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::types::deserialize_quantity_map"
+    )]
     pub requests: Option<HashMap<String, String>>,
 }
 
@@ -314,13 +322,21 @@ pub struct PersistentVolumeClaimStatus {
     pub phase: PersistentVolumeClaimPhase,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub access_modes: Option<Vec<PersistentVolumeAccessMode>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::types::deserialize_quantity_map"
+    )]
     pub capacity: Option<HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub conditions: Option<Vec<PersistentVolumeClaimCondition>>,
     /// Allocated resources represents the resources allocated to the PVC
     /// Used during volume expansion to track the new size
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::types::deserialize_quantity_map"
+    )]
     pub allocated_resources: Option<HashMap<String, String>>,
     /// AllocatedResourceStatuses stores status of resource being resized for the given PVC
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -226,14 +226,107 @@ pub struct LabelSelectorRequirement {
     pub values: Option<Vec<String>>,
 }
 
+/// Tolerant deserializer for `HashMap<String, String>` maps whose
+/// values represent Kubernetes `resource.Quantity` wire-form values.
+///
+/// Upstream `Quantity` round-trips as a JSON string (`"100m"`, `"1Gi"`),
+/// but the Go marshaller routes values through `inf.Dec` and several
+/// code paths emit a bare JSON number rather than a quoted string —
+/// notably zero-valued quantities defaulted from `int64` fields, and
+/// some legacy clients. K8s' Go deserialiser tolerates all three forms
+/// (`UnmarshalJSON` in `pkg/api/resource/quantity.go`).
+///
+/// Our previous plain `HashMap<String, String>` deserialiser rejected
+/// every pod-update body that carried a numeric `0` in
+/// `containers[*].resources.{requests,limits}` (column 942 of the
+/// canonical service-account-injected pod body). This function accepts
+/// `String`, integer, and float JSON values and renders each into the
+/// canonical string form so existing string-typed maps round-trip
+/// without forcing every caller to switch to a newtype.
+pub fn deserialize_quantity_map<'de, D>(
+    deserializer: D,
+) -> Result<Option<HashMap<String, String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::{MapAccess, Visitor};
+    use std::fmt;
+
+    struct OuterVisitor;
+    impl<'de> Visitor<'de> for OuterVisitor {
+        type Value = Option<HashMap<String, String>>;
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("null or a map<string, Quantity>")
+        }
+        fn visit_none<E>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+        fn visit_unit<E>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+        fn visit_some<D2>(self, d: D2) -> Result<Self::Value, D2::Error>
+        where
+            D2: Deserializer<'de>,
+        {
+            d.deserialize_map(InnerVisitor).map(Some)
+        }
+        fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+        where
+            A: MapAccess<'de>,
+        {
+            InnerVisitor.visit_map(map).map(Some)
+        }
+    }
+
+    struct InnerVisitor;
+    impl<'de> Visitor<'de> for InnerVisitor {
+        type Value = HashMap<String, String>;
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("a map<string, Quantity>")
+        }
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: MapAccess<'de>,
+        {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                let v: serde_json::Value = map.next_value()?;
+                let s = match v {
+                    serde_json::Value::String(s) => s,
+                    serde_json::Value::Number(n) => n.to_string(),
+                    serde_json::Value::Null => continue,
+                    other => {
+                        return Err(serde::de::Error::custom(format!(
+                            "Quantity value must be a string or number, got {}",
+                            other
+                        )));
+                    }
+                };
+                out.insert(key, s);
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_option(OuterVisitor)
+}
+
 /// Resource requirements for compute resources
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ResourceRequirements {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_quantity_map"
+    )]
     pub limits: Option<HashMap<String, String>>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_quantity_map"
+    )]
     pub requests: Option<HashMap<String, String>>,
 
     /// Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container

--- a/crates/common/tests/quantity_decode_test.rs
+++ b/crates/common/tests/quantity_decode_test.rs
@@ -1,0 +1,217 @@
+//! Regression tests for `deserialize_quantity_map`.
+//!
+//! Pin that pod / quota / limit-range bodies emitting a Quantity value
+//! as a bare JSON `0` / `1` / `1.5` (instead of the documented quoted
+//! string) are accepted by our decoder. K8s upstream Go does the same
+//! coercion in `pkg/api/resource/quantity.go::UnmarshalJSON`.
+//!
+//! Without this tolerance, every pod-update body that K8s' client-go
+//! sends with a defaulted/zero Quantity in `containers[*].resources`
+//! is rejected at column 942 with
+//!   `invalid type: integer 0, expected a string`
+//! which in turn blocks five `[Conformance]`-labelled tests.
+
+use rusternetes_common::resources::LimitRange;
+use rusternetes_common::resources::PersistentVolumeClaim;
+use rusternetes_common::resources::Pod;
+use rusternetes_common::resources::ResourceQuota;
+use serde_json::json;
+
+#[test]
+fn pod_decodes_integer_zero_request_quantity() {
+    // Mirrors the column-942 case: a pod body where client-go emitted
+    // `requests.cpu` as a bare JSON `0`.
+    let body = json!({
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": { "name": "p1", "namespace": "default" },
+        "spec": {
+            "containers": [{
+                "name": "c",
+                "image": "pause:latest",
+                "resources": {
+                    "requests": { "cpu": 0, "memory": "100Mi" },
+                    "limits":   { "cpu": "500m", "memory": "200Mi" }
+                }
+            }]
+        }
+    });
+    let pod: Pod = serde_json::from_value(body).expect("decode pod");
+    let reqs = pod.spec.as_ref().unwrap().containers[0]
+        .resources
+        .as_ref()
+        .unwrap()
+        .requests
+        .as_ref()
+        .unwrap();
+    // Integer zero must be coerced to the canonical-string form.
+    assert_eq!(reqs.get("cpu").map(String::as_str), Some("0"));
+    assert_eq!(reqs.get("memory").map(String::as_str), Some("100Mi"));
+}
+
+#[test]
+fn pod_decodes_float_quantity() {
+    let body = json!({
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": { "name": "p1", "namespace": "default" },
+        "spec": {
+            "containers": [{
+                "name": "c",
+                "image": "pause:latest",
+                "resources": {
+                    "limits": { "cpu": 1.5, "memory": "1Gi" }
+                }
+            }]
+        }
+    });
+    let pod: Pod = serde_json::from_value(body).expect("decode pod with float quantity");
+    let limits = pod.spec.as_ref().unwrap().containers[0]
+        .resources
+        .as_ref()
+        .unwrap()
+        .limits
+        .as_ref()
+        .unwrap();
+    assert_eq!(limits.get("cpu").map(String::as_str), Some("1.5"));
+    assert_eq!(limits.get("memory").map(String::as_str), Some("1Gi"));
+}
+
+#[test]
+fn pod_decodes_canonical_string_quantity() {
+    // The happy path that already worked — protect with a regression pin.
+    let body = json!({
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": { "name": "p1", "namespace": "default" },
+        "spec": {
+            "containers": [{
+                "name": "c",
+                "image": "pause:latest",
+                "resources": {
+                    "requests": { "cpu": "100m", "memory": "100Mi" }
+                }
+            }]
+        }
+    });
+    let pod: Pod = serde_json::from_value(body).expect("decode pod with string quantity");
+    let reqs = pod.spec.as_ref().unwrap().containers[0]
+        .resources
+        .as_ref()
+        .unwrap()
+        .requests
+        .as_ref()
+        .unwrap();
+    assert_eq!(reqs.get("cpu").map(String::as_str), Some("100m"));
+}
+
+#[test]
+fn resourcequota_decodes_integer_hard() {
+    let body = json!({
+        "apiVersion": "v1",
+        "kind": "ResourceQuota",
+        "metadata": { "name": "q", "namespace": "default" },
+        "spec": {
+            "hard": { "pods": 10, "requests.cpu": 0 }
+        },
+        "status": {
+            "hard": { "pods": 10 },
+            "used": { "pods": 0, "requests.cpu": "0" }
+        }
+    });
+    let rq: ResourceQuota = serde_json::from_value(body).expect("decode ResourceQuota");
+    let hard = rq.spec.hard.as_ref().unwrap();
+    assert_eq!(hard.get("pods").map(String::as_str), Some("10"));
+    assert_eq!(hard.get("requests.cpu").map(String::as_str), Some("0"));
+    let used = rq.status.as_ref().unwrap().used.as_ref().unwrap();
+    assert_eq!(used.get("pods").map(String::as_str), Some("0"));
+}
+
+#[test]
+fn limitrange_decodes_integer_max_min() {
+    let body = json!({
+        "apiVersion": "v1",
+        "kind": "LimitRange",
+        "metadata": { "name": "lr", "namespace": "default" },
+        "spec": {
+            "limits": [{
+                "type": "Container",
+                "max":     { "cpu": 2, "memory": "1Gi" },
+                "min":     { "cpu": 0, "memory": "16Mi" },
+                "default": { "cpu": "500m" }
+            }]
+        }
+    });
+    let lr: LimitRange = serde_json::from_value(body).expect("decode LimitRange");
+    let item = &lr.spec.limits[0];
+    assert_eq!(
+        item.max.as_ref().unwrap().get("cpu").map(String::as_str),
+        Some("2")
+    );
+    assert_eq!(
+        item.min.as_ref().unwrap().get("cpu").map(String::as_str),
+        Some("0")
+    );
+    assert_eq!(
+        item.default
+            .as_ref()
+            .unwrap()
+            .get("cpu")
+            .map(String::as_str),
+        Some("500m")
+    );
+}
+
+#[test]
+fn pvc_status_decodes_integer_capacity() {
+    let body = json!({
+        "apiVersion": "v1",
+        "kind": "PersistentVolumeClaim",
+        "metadata": { "name": "pvc", "namespace": "default" },
+        "spec": {
+            "accessModes": ["ReadWriteOnce"],
+            "resources": { "requests": { "storage": "1Gi" } }
+        },
+        "status": {
+            "phase": "Bound",
+            "capacity": { "storage": 0 },
+            "allocatedResources": { "storage": 0 }
+        }
+    });
+    let pvc: PersistentVolumeClaim = serde_json::from_value(body).expect("decode PVC");
+    let status = pvc.status.as_ref().unwrap();
+    assert_eq!(
+        status
+            .capacity
+            .as_ref()
+            .unwrap()
+            .get("storage")
+            .map(String::as_str),
+        Some("0")
+    );
+    assert_eq!(
+        status
+            .allocated_resources
+            .as_ref()
+            .unwrap()
+            .get("storage")
+            .map(String::as_str),
+        Some("0")
+    );
+}
+
+#[test]
+fn pod_decodes_omitted_resources_block() {
+    // A pod body with no resources field at all must still decode.
+    // Defends the `default` + `skip_serializing_if` attributes.
+    let body = json!({
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": { "name": "p1", "namespace": "default" },
+        "spec": {
+            "containers": [{ "name": "c", "image": "pause:latest" }]
+        }
+    });
+    let pod: Pod = serde_json::from_value(body).expect("decode pod without resources");
+    assert!(pod.spec.as_ref().unwrap().containers[0].resources.is_none());
+}


### PR DESCRIPTION
## Summary

`resource.Quantity` is documented to round-trip as a JSON string (`\"100m\"`, `\"1Gi\"`), but the Go marshaller emits bare numbers in several paths — most notably zero-valued quantities defaulted from `int64` fields. Upstream `pkg/api/resource/quantity.go::UnmarshalJSON` accepts string, integer, and float forms.

Our previous `HashMap<String, String>` decode rejected every body carrying a bare numeric `0` in `containers[*].resources.{requests,limits}`, surfacing as:

\`\`\`
failed to decode: invalid type: integer 0, expected a string at line 1 column 942
\`\`\`

This blocked five `[Conformance]` tests that exercise the `ValidatePodUpdate` fence.

### Fix

Add `crates/common/src/types.rs::deserialize_quantity_map` — a `deserialize_with` helper that wraps `Option<HashMap<String, String>>` to accept JSON `String`, integer, and float values, normalising integers/floats via `Number::to_string()`. Serialisation is unchanged (canonical string form).

Helper applied at every Quantity-bearing call site (Pod ContainerStatus + Overhead, PVC capacity + allocated, NodeStatus capacity/allocatable, ResourceQuota/LimitRange specs, etc).

### Tests

7 fixtures in `crates/common/tests/quantity_decode_test.rs` cover the column-942 case, omitted-resources blocks, integer/float/canonical-string round-trips, and integer-valued PVC capacity, LimitRange, and ResourceQuota fields.

## Test plan

- [x] \`cargo test -p rusternetes-common --test quantity_decode_test\` — 7/7 pass
- [x] \`cargo fmt --all -- --check\` clean