### PR TITLE
fix(common): treat empty enum strings as None on deserialize

### DIFF
--- a/crates/common/src/resources.rs
+++ b/crates/common/src/resources.rs
@@ -28,6 +28,7 @@ pub mod pod;
 pub mod policy;
 pub mod rbac;
 pub mod runtimeclass;
+pub mod serde_helpers;
 pub mod service;
 pub mod service_account;
 pub mod servicecidr;

--- a/crates/common/src/resources/admission_webhook.rs
+++ b/crates/common/src/resources/admission_webhook.rs
@@ -3,6 +3,7 @@
 // This module defines ValidatingWebhookConfiguration and MutatingWebhookConfiguration
 // resources that configure external admission webhooks.
 
+use crate::resources::serde_helpers::empty_string_as_none;
 use crate::resources::WebhookClientConfig;
 use crate::types::ObjectMeta;
 use serde::{Deserialize, Serialize};
@@ -43,11 +44,19 @@ pub struct ValidatingWebhook {
     pub rules: Vec<RuleWithOperations>,
 
     /// FailurePolicy defines how unrecognized errors are handled
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub failure_policy: Option<FailurePolicy>,
 
     /// MatchPolicy defines how the rules are applied
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub match_policy: Option<MatchPolicy>,
 
     /// NamespaceSelector decides whether to run the webhook on an object based on namespace
@@ -109,11 +118,19 @@ pub struct MutatingWebhook {
     pub rules: Vec<RuleWithOperations>,
 
     /// FailurePolicy defines how unrecognized errors are handled
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub failure_policy: Option<FailurePolicy>,
 
     /// MatchPolicy defines how the rules are applied
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub match_policy: Option<MatchPolicy>,
 
     /// NamespaceSelector decides whether to run the webhook on an object based on namespace
@@ -139,7 +156,11 @@ pub struct MutatingWebhook {
     pub match_conditions: Option<Vec<MatchCondition>>,
 
     /// ReinvocationPolicy indicates whether this webhook should be called multiple times
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub reinvocation_policy: Option<ReinvocationPolicy>,
 }
 

--- a/crates/common/src/resources/csi.rs
+++ b/crates/common/src/resources/csi.rs
@@ -1,3 +1,4 @@
+use crate::resources::serde_helpers::empty_string_as_none;
 use crate::resources::service_account::ObjectReference;
 use crate::resources::volume::LabelSelector;
 use crate::types::{ObjectMeta, TypeMeta};
@@ -26,7 +27,11 @@ pub struct CSIDriverSpec {
     pub pod_info_on_mount: Option<bool>,
 
     /// fsGroupPolicy defines if the volume supports changing ownership and permission of the volume
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub fs_group_policy: Option<FSGroupPolicy>,
 
     /// storageCapacity indicates that the CSI volume driver wants pod scheduling to consider storage capacity

--- a/crates/common/src/resources/dra.rs
+++ b/crates/common/src/resources/dra.rs
@@ -5,6 +5,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
+use super::serde_helpers::empty_string_as_none;
 use super::NodeSelector;
 
 // =============================================================================
@@ -95,7 +96,8 @@ pub struct ExactDeviceRequest {
     #[serde(
         rename = "allocationMode",
         default,
-        skip_serializing_if = "Option::is_none"
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "empty_string_as_none"
     )]
     pub allocation_mode: Option<DeviceAllocationMode>,
 
@@ -167,7 +169,11 @@ pub struct DeviceToleration {
     pub effect: DeviceTaintEffect,
 
     /// Operator represents a key's relationship to the value
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub operator: Option<TolerationOperator>,
 }
 

--- a/crates/common/src/resources/serde_helpers.rs
+++ b/crates/common/src/resources/serde_helpers.rs
@@ -1,0 +1,75 @@
+//! Serde helpers shared across resource types.
+//!
+//! Kubernetes API clients sometimes serialize unset enum-typed fields as the
+//! empty string instead of omitting them. Upstream Go decoders accept the
+//! zero-value; strict Rust serde enums reject it as an unknown variant.
+//! `empty_string_as_none` bridges that gap for `Option<T>` fields whose
+//! underlying type is a string-tagged enum.
+
+use serde::{Deserialize, Deserializer};
+
+/// Deserialize an `Option<T>` where the JSON value may be `null`, missing,
+/// or the empty string. Empty strings are coerced to `None` before falling
+/// through to `T`'s own deserializer.
+pub fn empty_string_as_none<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    match value {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(serde_json::Value::String(s)) if s.is_empty() => Ok(None),
+        Some(v) => T::deserialize(v)
+            .map(Some)
+            .map_err(serde::de::Error::custom),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    enum Policy {
+        Cluster,
+        Local,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct Holder {
+        #[serde(default, deserialize_with = "empty_string_as_none")]
+        policy: Option<Policy>,
+    }
+
+    #[test]
+    fn empty_string_becomes_none() {
+        let h: Holder = serde_json::from_str(r#"{"policy": ""}"#).unwrap();
+        assert_eq!(h.policy, None);
+    }
+
+    #[test]
+    fn missing_field_becomes_none() {
+        let h: Holder = serde_json::from_str(r#"{}"#).unwrap();
+        assert_eq!(h.policy, None);
+    }
+
+    #[test]
+    fn null_becomes_none() {
+        let h: Holder = serde_json::from_str(r#"{"policy": null}"#).unwrap();
+        assert_eq!(h.policy, None);
+    }
+
+    #[test]
+    fn named_variant_passes_through() {
+        let h: Holder = serde_json::from_str(r#"{"policy": "Local"}"#).unwrap();
+        assert_eq!(h.policy, Some(Policy::Local));
+    }
+
+    #[test]
+    fn bogus_variant_still_errors() {
+        let r: Result<Holder, _> = serde_json::from_str(r#"{"policy": "Galactic"}"#);
+        assert!(r.is_err());
+    }
+}

--- a/crates/common/src/resources/service.rs
+++ b/crates/common/src/resources/service.rs
@@ -1,4 +1,5 @@
 use crate::resources::policy::IntOrString;
+use crate::resources::serde_helpers::empty_string_as_none;
 use crate::types::{Condition, ObjectMeta, TypeMeta};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -39,7 +40,12 @@ pub struct ServiceSpec {
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub ports: Vec<ServicePort>,
 
-    #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
+    #[serde(
+        default,
+        rename = "type",
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub service_type: Option<ServiceType>,
 
     #[serde(skip_serializing_if = "Option::is_none", rename = "clusterIP")]
@@ -68,18 +74,30 @@ pub struct ServiceSpec {
 
     /// IPFamilyPolicy represents the dual-stack-ness requested or required by this Service.
     /// Can be SingleStack, PreferDualStack, or RequireDualStack.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub ip_family_policy: Option<IPFamilyPolicy>,
 
     /// InternalTrafficPolicy specifies if the cluster internal traffic should be routed to all endpoints
     /// or node-local endpoints only. "Cluster" routes to all endpoints. "Local" routes to node-local endpoints.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub internal_traffic_policy: Option<ServiceInternalTrafficPolicy>,
 
     /// ExternalTrafficPolicy denotes if this Service desires to route external traffic to node-local or
     /// cluster-wide endpoints. "Local" preserves the client source IP and avoids a second hop for LoadBalancer
     /// and Nodeport type services, but risks potentially imbalanced traffic spreading.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub external_traffic_policy: Option<ServiceExternalTrafficPolicy>,
 
     /// HealthCheckNodePort specifies the healthcheck nodePort for the service (when type=LoadBalancer and externalTrafficPolicy=Local)
@@ -424,5 +442,80 @@ mod tests {
         }"#;
         let svc: Service = serde_json::from_str(json).unwrap();
         assert!(svc.spec.selector.is_none());
+    }
+
+    /// Regression: upstream e2e (and client-go in general) serialize unset
+    /// enum-typed Option<_> fields as the empty string instead of omitting
+    /// them. Without empty_string_as_none, strict serde rejects "" with
+    /// `unknown variant ''` and the api-server returns 422 before any
+    /// handler runs, breaking `[sig-node] Pods should contain environment
+    /// variables for services` and every other test that builds a Service
+    /// via framework helpers.
+    #[test]
+    fn service_spec_accepts_empty_enum_strings() {
+        let json = r#"{
+            "type": "",
+            "ipFamilyPolicy": "",
+            "internalTrafficPolicy": "",
+            "externalTrafficPolicy": ""
+        }"#;
+        let spec: ServiceSpec = serde_json::from_str(json).unwrap();
+        assert!(spec.service_type.is_none());
+        assert!(spec.ip_family_policy.is_none());
+        assert!(spec.internal_traffic_policy.is_none());
+        assert!(spec.external_traffic_policy.is_none());
+    }
+
+    #[test]
+    fn service_spec_still_accepts_named_enum_variants() {
+        let json = r#"{
+            "type": "ClusterIP",
+            "ipFamilyPolicy": "SingleStack",
+            "internalTrafficPolicy": "Cluster",
+            "externalTrafficPolicy": "Local"
+        }"#;
+        let spec: ServiceSpec = serde_json::from_str(json).unwrap();
+        assert_eq!(spec.service_type, Some(ServiceType::ClusterIP));
+        assert_eq!(spec.ip_family_policy, Some(IPFamilyPolicy::SingleStack));
+        assert_eq!(
+            spec.internal_traffic_policy,
+            Some(ServiceInternalTrafficPolicy::Cluster)
+        );
+        assert_eq!(
+            spec.external_traffic_policy,
+            Some(ServiceExternalTrafficPolicy::Local)
+        );
+    }
+
+    #[test]
+    fn service_spec_rejects_genuinely_bogus_enum_strings() {
+        let json = r#"{ "externalTrafficPolicy": "NotARealPolicy" }"#;
+        let r: Result<ServiceSpec, _> = serde_json::from_str(json);
+        assert!(r.is_err(), "unknown non-empty variant must still error");
+    }
+
+    /// The e2e payload that triggered the bug, captured verbatim from the
+    /// `[sig-node] Pods should contain environment variables for services`
+    /// failure on node-1.
+    #[test]
+    fn service_e2e_envvars_payload_deserializes() {
+        let json = r#"{
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {"name": "fooservice"},
+            "spec": {
+                "selector": {"name": "server-envvars"},
+                "ports": [{"port": 8765, "targetPort": 8080}],
+                "type": "",
+                "internalTrafficPolicy": "",
+                "externalTrafficPolicy": "",
+                "ipFamilyPolicy": ""
+            }
+        }"#;
+        let svc: Service = serde_json::from_str(json).unwrap();
+        assert!(svc.spec.service_type.is_none());
+        assert!(svc.spec.internal_traffic_policy.is_none());
+        assert!(svc.spec.external_traffic_policy.is_none());
+        assert!(svc.spec.ip_family_policy.is_none());
     }
 }

--- a/crates/common/src/resources/validating_admission_policy.rs
+++ b/crates/common/src/resources/validating_admission_policy.rs
@@ -3,6 +3,7 @@
 // This module defines ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding
 // resources that enable CEL-based admission control.
 
+use crate::resources::serde_helpers::empty_string_as_none;
 use crate::resources::{LabelSelector, MatchCondition};
 use crate::types::ObjectMeta;
 use serde::{Deserialize, Serialize};
@@ -49,7 +50,11 @@ pub struct ValidatingAdmissionPolicySpec {
     pub validations: Option<Vec<Validation>>,
 
     /// FailurePolicy defines how to handle failures for the admission policy
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub failure_policy: Option<FailurePolicy>,
 
     /// AuditAnnotations contains CEL expressions which are used to produce audit annotations
@@ -98,7 +103,11 @@ pub struct MatchResources {
     pub exclude_resource_rules: Option<Vec<NamedRuleWithOperations>>,
 
     /// MatchPolicy defines how the "rules" list is used to match incoming requests
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub match_policy: Option<MatchPolicyType>,
 }
 
@@ -368,7 +377,11 @@ pub struct ParamRef {
     pub selector: Option<LabelSelector>,
 
     /// ParameterNotFoundAction controls the behavior when the param resource is not found
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub parameter_not_found_action: Option<ParameterNotFoundAction>,
 }
 

--- a/crates/common/src/resources/volume.rs
+++ b/crates/common/src/resources/volume.rs
@@ -1,3 +1,4 @@
+use crate::resources::serde_helpers::empty_string_as_none;
 use crate::resources::service_account::ObjectReference;
 use crate::types::{ObjectMeta, TypeMeta};
 use chrono::{DateTime, Utc};
@@ -26,7 +27,11 @@ pub struct PersistentVolumeSpec {
     pub access_modes: Vec<PersistentVolumeAccessMode>,
 
     /// Reclaim policy
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub persistent_volume_reclaim_policy: Option<PersistentVolumeReclaimPolicy>,
 
     /// Storage class name
@@ -38,7 +43,11 @@ pub struct PersistentVolumeSpec {
     pub mount_options: Option<Vec<String>>,
 
     /// Volume mode
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub volume_mode: Option<PersistentVolumeMode>,
 
     /// Node affinity
@@ -74,7 +83,11 @@ pub struct PersistentVolumeSpec {
 #[serde(rename_all = "camelCase")]
 pub struct HostPathVolumeSource {
     pub path: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub r#type: Option<HostPathType>,
 }
 
@@ -240,7 +253,11 @@ pub struct PersistentVolumeClaimSpec {
     pub storage_class_name: Option<String>,
 
     /// Volume mode
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub volume_mode: Option<PersistentVolumeMode>,
 
     /// Selector for PV
@@ -408,11 +425,19 @@ pub struct StorageClass {
     pub parameters: Option<HashMap<String, String>>,
 
     /// Reclaim policy
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub reclaim_policy: Option<PersistentVolumeReclaimPolicy>,
 
     /// Volume binding mode
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "empty_string_as_none"
+    )]
     pub volume_binding_mode: Option<VolumeBindingMode>,
 
     /// Allowed topologies

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -195,12 +195,21 @@ pub struct TypeMeta {
 }
 
 /// Resource status phase
+///
+/// `Unknown` carries `#[serde(alias = "")]` because kubectl / client-go send
+/// `status: { phase: "" }` on CREATE for resources where the server assigns
+/// the phase (namespace, pod, etc.). Upstream Kubernetes accepts the empty
+/// string and overwrites it; without this alias `Option<Phase>` rejects the
+/// empty inner string and the api-server returns 422 before any handler
+/// runs, breaking every kubectl-driven CREATE including the one hydrophone
+/// + sonobuoy issue to bootstrap their test namespace.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum Phase {
     Pending,
     Running,
     Succeeded,
     Failed,
+    #[serde(alias = "")]
     Unknown,
     Active,
     Terminating,
@@ -781,5 +790,51 @@ mod tests {
         // Re-serialize (as our API server does when responding to client)
         let json2 = serde_json::to_string(&meta2).unwrap();
         assert_eq!(json, json2, "Timestamp should survive round-trip");
+    }
+
+    /// Regression: kubectl / client-go send `status: { phase: "" }` on CREATE
+    /// for namespace/pod/etc. — server is meant to assign the phase. Without
+    /// `#[serde(alias = "")]` on `Phase::Unknown` the api-server returned 422
+    /// before any handler ran and `kubectl create ns <X>` was uniformly broken,
+    /// taking hydrophone + sonobuoy down with it.
+    #[test]
+    fn phase_accepts_empty_string_on_input() {
+        let p: Phase = serde_json::from_str(r#""""#).unwrap();
+        assert_eq!(p, Phase::Unknown);
+    }
+
+    #[test]
+    fn phase_named_variants_still_deserialize() {
+        for (input, expected) in [
+            (r#""Pending""#, Phase::Pending),
+            (r#""Running""#, Phase::Running),
+            (r#""Active""#, Phase::Active),
+            (r#""Terminating""#, Phase::Terminating),
+            (r#""Unknown""#, Phase::Unknown),
+        ] {
+            let parsed: Phase = serde_json::from_str(input).unwrap();
+            assert_eq!(
+                parsed, expected,
+                "input {} should yield {:?}",
+                input, expected
+            );
+        }
+    }
+
+    /// Output wire format must NOT change: `Phase::Unknown` still serializes as
+    /// `"Unknown"`, not the empty string. The alias is an input-only synonym so
+    /// upstream-shape persistence is preserved.
+    #[test]
+    fn phase_unknown_serializes_as_unknown_not_empty() {
+        let json = serde_json::to_string(&Phase::Unknown).unwrap();
+        assert_eq!(json, r#""Unknown""#);
+    }
+
+    /// Genuinely invalid variants must still fail loudly — the alias is only
+    /// for the empty string, not a catch-all.
+    #[test]
+    fn phase_rejects_unknown_non_empty_variants() {
+        let r: Result<Phase, _> = serde_json::from_str(r#""NotAPhase""#);
+        assert!(r.is_err(), "unknown non-empty variant must error");
     }
 }

--- a/crates/common/tests/null_field_deserialization_test.rs
+++ b/crates/common/tests/null_field_deserialization_test.rs
@@ -1,0 +1,98 @@
+// Regression tests for null-field deserialization fixes.
+//
+// Real Kubernetes clients (kubectl, go-client) sometimes send JSON with explicit
+// `null` for optional fields. The five commits below all fixed deserialization
+// panics when these fields were `null`. These tests ensure the fixes stay in
+// place by sending exactly the null JSON that triggered each original bug.
+//
+// Commits covered:
+//   2332cf4  fix: ObjectMeta — tolerate null name during deserialization
+//   b5e457c  fix: EndpointAddress ip — handle null values like ObjectMeta.name
+//   c2364a3  Fix #241: TokenRequest audiences field accepts null
+//   ff43065  Fix #212: EndpointSlice ports field accepts null
+//   402d503  Fix CSINode null drivers + ResourceQuota status route
+
+use rusternetes_common::resources::{
+    CSINodeSpec, EndpointAddress, EndpointSlice, TokenRequestSpec,
+};
+use rusternetes_common::types::ObjectMeta;
+use serde_json::json;
+
+// ---------------------------------------------------------------------------
+// 2332cf4 — ObjectMeta.name tolerates null
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_object_meta_tolerates_null_name() {
+    // kubectl strategic-merge-patch can produce {"name": null} when the patch
+    // body omits name. Without deserialize_null_string this returns Err.
+    let v = json!({"name": null, "namespace": "default"});
+    let m: ObjectMeta = serde_json::from_value(v)
+        .expect("ObjectMeta with name=null must deserialize without error");
+    // null maps to empty string (Go zero-value behaviour)
+    assert_eq!(m.name, "");
+}
+
+// ---------------------------------------------------------------------------
+// b5e457c — EndpointAddress.ip tolerates null
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_endpoint_address_tolerates_null_ip() {
+    // Endpoints stored in etcd may have ip: null from protobuf decode or
+    // initial creation. Without deserialize_null_string this returns Err.
+    let v = json!({"ip": null});
+    let a: EndpointAddress = serde_json::from_value(v)
+        .expect("EndpointAddress with ip=null must deserialize without error");
+    assert_eq!(a.ip, "");
+}
+
+// ---------------------------------------------------------------------------
+// c2364a3 — TokenRequestSpec.audiences tolerates null
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_token_request_spec_tolerates_null_audiences() {
+    // The K8s client sends {"audiences": null} when no audiences are specified.
+    // Without deserialize_null_default this returns Err ("invalid type: null,
+    // expected a sequence").
+    let v = json!({"audiences": null});
+    let s: TokenRequestSpec = serde_json::from_value(v)
+        .expect("TokenRequestSpec with audiences=null must deserialize without error");
+    // null → empty Vec (Go zero-value behaviour)
+    assert!(s.audiences.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// ff43065 — EndpointSlice.ports tolerates null
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_endpoint_slice_tolerates_null_ports() {
+    // The K8s conformance test sends {"ports": null}. Before the fix,
+    // serde(default) handled *missing* fields but not explicit null.
+    let v = json!({
+        "apiVersion": "discovery.k8s.io/v1",
+        "kind": "EndpointSlice",
+        "metadata": {"name": "test"},
+        "addressType": "IPv4",
+        "ports": null
+    });
+    let es: EndpointSlice = serde_json::from_value(v)
+        .expect("EndpointSlice with ports=null must deserialize without error");
+    assert!(es.ports.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// 402d503 — CSINodeSpec.drivers tolerates null
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_csi_node_spec_tolerates_null_drivers() {
+    // CSINode kubelet registration can produce {"drivers": null} on first
+    // write. Without deserialize_null_default this returns Err.
+    let v = json!({"drivers": null});
+    let s: CSINodeSpec = serde_json::from_value(v)
+        .expect("CSINodeSpec with drivers=null must deserialize without error");
+    assert!(s.drivers.is_empty());
+}


### PR DESCRIPTION
## Summary

Three related decoder fixes that unblock kubectl/client-go-driven CREATE flows.

### 1. Empty enum strings → `None`

kubectl frequently sends `\"\"` for enum-typed fields where the server is expected to compute the value. Without tolerance, serde rejects the body with `unknown variant \"\"` and the request fails before any handler runs. New `crates/common/src/resources/serde_helpers.rs` provides a reusable `deserialize_empty_string_as_none` helper, applied to enum fields across resources.

### 2. `Phase` empty-string alias

Same problem, narrower scope: `kubectl create ns conformance` sends `status: { phase: \"\" }`. Upstream accepts and overwrites. We now decode the empty string as \`Phase::Unknown\` via `#[serde(alias = \"\")]`. Wire output is unchanged — `Phase::Unknown` still serialises as \`\"Unknown\"\`. Verified end-to-end on a live cluster: hydrophone and sonobuoy bootstrap namespaces succeed.

### 3. Null-field deserialisation regression tests

5 tests in `crates/common/tests/null_field_deserialization_test.rs` pin previous fixes for null-tolerance on `ObjectMeta.name`, `EndpointAddress.ip`, `TokenRequestSpec.audiences`, `EndpointSlice.ports`, and `CSINodeSpec.drivers`. Each test reverts to a pre-fix \`expected sequence\` / \`expected string\` panic if the corresponding fix is removed.

## Test plan

- [x] \`cargo test -p rusternetes-common --test null_field_deserialization_test\` — 5/5 pass
- [x] \`cargo test -p rusternetes-common --lib\` — 287 pass, 2 ignored
- [x] \`cargo fmt --all -- --check\` clean