### PR TITLE
test(common): add JSON roundtrip tests for all major API groups

### DIFF
--- a/crates/common/tests/roundtrip_apps_v1.rs
+++ b/crates/common/tests/roundtrip_apps_v1.rs
@@ -1,0 +1,771 @@
+//! Hand-written JSON roundtrip tests for apps/v1 resources.
+//!
+//! Mirrors the upstream Kubernetes test layer that exercises
+//! `k8s.io/api/apps/v1` types through JSON (de)serialization. Each fixture
+//! verifies the four-step roundtrip contract:
+//!
+//!   1. `serde_json::from_str::<T>(&fixture)` succeeds.
+//!   2. `serde_json::to_string(&decoded)` succeeds.
+//!   3. `serde_json::from_str::<T>(&re_encoded)` succeeds.
+//!   4. The JSON value produced by step (2) re-encodes byte-identically
+//!      after a second decode pass — i.e. the canonical JSON shape is a
+//!      fixed point of the encode/decode round.
+//!
+//! Because most apps/v1 top-level structs in this crate do not derive
+//! `PartialEq` (they hold deeply-nested types like `PodSpec` that include
+//! `serde_json::Value` for typed-but-opaque fields), we assert stability
+//! via `serde_json::Value` equality of two successive encodings. This is
+//! the same property upstream's `RoundTrip` helpers establish.
+
+use rusternetes_common::resources::controllerrevision::ControllerRevision;
+use rusternetes_common::resources::deployment::Deployment;
+use rusternetes_common::resources::workloads::{DaemonSet, ReplicaSet, StatefulSet};
+use rusternetes_common::types::List;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+/// Runs the four-step JSON roundtrip contract against a hand-written
+/// fixture. Asserts that the second decode + re-encode produces a value
+/// identical (as a `serde_json::Value`) to the first re-encode.
+fn assert_roundtrip<T>(fixture: &str)
+where
+    T: DeserializeOwned + Serialize,
+{
+    // 1. Decode the fixture.
+    let decoded: T =
+        serde_json::from_str(fixture).expect("step 1: fixture must deserialize into T");
+
+    // 2. Re-encode.
+    let re_encoded = serde_json::to_string(&decoded).expect("step 2: decoded value must serialize");
+
+    // 3. Decode the re-encoded form.
+    let re_decoded: T =
+        serde_json::from_str(&re_encoded).expect("step 3: re-encoded form must deserialize");
+
+    // 4. Stability check: encode the second decode and compare JSON values.
+    let re_re_encoded =
+        serde_json::to_string(&re_decoded).expect("step 4a: re-decoded value must serialize");
+
+    let a: serde_json::Value = serde_json::from_str(&re_encoded)
+        .expect("step 4b: first re-encoding must parse as JSON Value");
+    let b: serde_json::Value = serde_json::from_str(&re_re_encoded)
+        .expect("step 4c: second re-encoding must parse as JSON Value");
+    assert_eq!(
+        a, b,
+        "roundtrip unstable: re-encoded JSON drifted on second pass.\n\
+         first:  {re_encoded}\n\
+         second: {re_re_encoded}",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Deployment fixtures
+// ---------------------------------------------------------------------------
+
+#[test]
+fn roundtrip_deployment_minimal() {
+    let fixture = r#"{
+        "kind": "Deployment",
+        "apiVersion": "apps/v1",
+        "metadata": {"name": "nginx", "namespace": "default"},
+        "spec": {
+            "selector": {"matchLabels": {"app": "nginx"}},
+            "template": {
+                "metadata": {"labels": {"app": "nginx"}},
+                "spec": {"containers": [{"name": "nginx", "image": "nginx:1.21"}]}
+            }
+        }
+    }"#;
+    assert_roundtrip::<Deployment>(fixture);
+}
+
+#[test]
+fn roundtrip_deployment_full_featured() {
+    let fixture = r#"{
+        "kind": "Deployment",
+        "apiVersion": "apps/v1",
+        "metadata": {
+            "name": "web",
+            "namespace": "production",
+            "labels": {"app": "web", "tier": "frontend"},
+            "annotations": {"deployment.kubernetes.io/revision": "3"},
+            "generation": 4
+        },
+        "spec": {
+            "replicas": 5,
+            "selector": {"matchLabels": {"app": "web"}},
+            "template": {
+                "metadata": {"labels": {"app": "web"}},
+                "spec": {
+                    "containers": [{
+                        "name": "web",
+                        "image": "nginx:1.25",
+                        "ports": [{"containerPort": 80, "protocol": "TCP"}]
+                    }],
+                    "restartPolicy": "Always"
+                }
+            },
+            "strategy": {
+                "type": "RollingUpdate",
+                "rollingUpdate": {"maxSurge": "25%", "maxUnavailable": "25%"}
+            },
+            "minReadySeconds": 10,
+            "revisionHistoryLimit": 10,
+            "paused": false,
+            "progressDeadlineSeconds": 600
+        },
+        "status": {
+            "replicas": 5,
+            "updatedReplicas": 5,
+            "readyReplicas": 5,
+            "availableReplicas": 5,
+            "observedGeneration": 4,
+            "conditions": [
+                {
+                    "type": "Available",
+                    "status": "True",
+                    "reason": "MinimumReplicasAvailable",
+                    "message": "Deployment has minimum availability."
+                }
+            ]
+        }
+    }"#;
+    assert_roundtrip::<Deployment>(fixture);
+}
+
+#[test]
+fn roundtrip_deployment_recreate_strategy() {
+    // Recreate strategy has no rollingUpdate sub-field.
+    let fixture = r#"{
+        "kind": "Deployment",
+        "apiVersion": "apps/v1",
+        "metadata": {"name": "db", "namespace": "default"},
+        "spec": {
+            "selector": {"matchLabels": {"app": "db"}},
+            "template": {
+                "metadata": {"labels": {"app": "db"}},
+                "spec": {"containers": [{"name": "db", "image": "postgres:16"}]}
+            },
+            "strategy": {"type": "Recreate"}
+        }
+    }"#;
+    assert_roundtrip::<Deployment>(fixture);
+}
+
+#[test]
+fn roundtrip_deployment_status_subresource() {
+    // Status-only payload as returned by the /status subresource. Some
+    // controllers omit `spec` entirely when reading via /status; the type
+    // requires spec, so we include a minimal one matching upstream behaviour.
+    let fixture = r#"{
+        "kind": "Deployment",
+        "apiVersion": "apps/v1",
+        "metadata": {"name": "status-only", "namespace": "default"},
+        "spec": {
+            "selector": {"matchLabels": {"app": "status-only"}},
+            "template": {
+                "metadata": {"labels": {"app": "status-only"}},
+                "spec": {"containers": [{"name": "c", "image": "busybox"}]}
+            }
+        },
+        "status": {
+            "replicas": 3,
+            "updatedReplicas": 2,
+            "readyReplicas": 2,
+            "availableReplicas": 2,
+            "unavailableReplicas": 1,
+            "collisionCount": 0,
+            "observedGeneration": 7,
+            "terminatingReplicas": 0
+        }
+    }"#;
+    assert_roundtrip::<Deployment>(fixture);
+}
+
+#[test]
+fn roundtrip_deployment_list_wrapper() {
+    let fixture = r#"{
+        "kind": "DeploymentList",
+        "apiVersion": "apps/v1",
+        "metadata": {"resourceVersion": "12345"},
+        "items": [
+            {
+                "kind": "Deployment",
+                "apiVersion": "apps/v1",
+                "metadata": {"name": "a", "namespace": "default"},
+                "spec": {
+                    "selector": {"matchLabels": {"app": "a"}},
+                    "template": {
+                        "metadata": {"labels": {"app": "a"}},
+                        "spec": {"containers": [{"name": "a", "image": "busybox"}]}
+                    }
+                }
+            },
+            {
+                "kind": "Deployment",
+                "apiVersion": "apps/v1",
+                "metadata": {"name": "b", "namespace": "default"},
+                "spec": {
+                    "replicas": 2,
+                    "selector": {"matchLabels": {"app": "b"}},
+                    "template": {
+                        "metadata": {"labels": {"app": "b"}},
+                        "spec": {"containers": [{"name": "b", "image": "busybox"}]}
+                    }
+                }
+            }
+        ]
+    }"#;
+    assert_roundtrip::<List<Deployment>>(fixture);
+}
+
+#[test]
+fn roundtrip_deployment_max_surge_integer() {
+    // IntOrString edge case: integer maxSurge/maxUnavailable, not percent.
+    let fixture = r#"{
+        "kind": "Deployment",
+        "apiVersion": "apps/v1",
+        "metadata": {"name": "int-surge", "namespace": "default"},
+        "spec": {
+            "selector": {"matchLabels": {"app": "int-surge"}},
+            "template": {
+                "metadata": {"labels": {"app": "int-surge"}},
+                "spec": {"containers": [{"name": "c", "image": "busybox"}]}
+            },
+            "strategy": {
+                "type": "RollingUpdate",
+                "rollingUpdate": {"maxSurge": 1, "maxUnavailable": 0}
+            }
+        }
+    }"#;
+    assert_roundtrip::<Deployment>(fixture);
+}
+
+// ---------------------------------------------------------------------------
+// ReplicaSet fixtures
+// ---------------------------------------------------------------------------
+
+#[test]
+fn roundtrip_replicaset_minimal() {
+    let fixture = r#"{
+        "kind": "ReplicaSet",
+        "apiVersion": "apps/v1",
+        "metadata": {"name": "frontend", "namespace": "default"},
+        "spec": {
+            "replicas": 3,
+            "selector": {"matchLabels": {"tier": "frontend"}},
+            "template": {
+                "metadata": {"labels": {"tier": "frontend"}},
+                "spec": {"containers": [{"name": "php-redis", "image": "gcr.io/google_samples/gb-frontend:v3"}]}
+            }
+        }
+    }"#;
+    assert_roundtrip::<ReplicaSet>(fixture);
+}
+
+#[test]
+fn roundtrip_replicaset_full_featured() {
+    let fixture = r#"{
+        "kind": "ReplicaSet",
+        "apiVersion": "apps/v1",
+        "metadata": {
+            "name": "backend",
+            "namespace": "production",
+            "labels": {"app": "backend"},
+            "ownerReferences": [{
+                "apiVersion": "apps/v1",
+                "kind": "Deployment",
+                "name": "backend",
+                "uid": "abc-123-def",
+                "controller": true,
+                "blockOwnerDeletion": true
+            }]
+        },
+        "spec": {
+            "replicas": 4,
+            "selector": {
+                "matchLabels": {"app": "backend"},
+                "matchExpressions": [
+                    {"key": "tier", "operator": "In", "values": ["backend", "api"]}
+                ]
+            },
+            "template": {
+                "metadata": {"labels": {"app": "backend", "tier": "backend"}},
+                "spec": {
+                    "containers": [{"name": "backend", "image": "myapp:v2"}]
+                }
+            },
+            "minReadySeconds": 5
+        },
+        "status": {
+            "replicas": 4,
+            "fullyLabeledReplicas": 4,
+            "readyReplicas": 4,
+            "availableReplicas": 4,
+            "observedGeneration": 1
+        }
+    }"#;
+    assert_roundtrip::<ReplicaSet>(fixture);
+}
+
+#[test]
+fn roundtrip_replicaset_status_subresource() {
+    let fixture = r#"{
+        "kind": "ReplicaSet",
+        "apiVersion": "apps/v1",
+        "metadata": {"name": "rs-status", "namespace": "default"},
+        "spec": {
+            "replicas": 2,
+            "selector": {"matchLabels": {"app": "rs-status"}},
+            "template": {
+                "metadata": {"labels": {"app": "rs-status"}},
+                "spec": {"containers": [{"name": "c", "image": "busybox"}]}
+            }
+        },
+        "status": {
+            "replicas": 2,
+            "readyReplicas": 1,
+            "availableReplicas": 1,
+            "observedGeneration": 3,
+            "conditions": [
+                {"type": "ReplicaFailure", "status": "False"}
+            ],
+            "terminatingReplicas": 0
+        }
+    }"#;
+    assert_roundtrip::<ReplicaSet>(fixture);
+}
+
+#[test]
+fn roundtrip_replicaset_list_wrapper() {
+    let fixture = r#"{
+        "kind": "ReplicaSetList",
+        "apiVersion": "apps/v1",
+        "metadata": {"resourceVersion": "9000"},
+        "items": [
+            {
+                "kind": "ReplicaSet",
+                "apiVersion": "apps/v1",
+                "metadata": {"name": "one", "namespace": "default"},
+                "spec": {
+                    "replicas": 1,
+                    "selector": {"matchLabels": {"n": "one"}},
+                    "template": {
+                        "metadata": {"labels": {"n": "one"}},
+                        "spec": {"containers": [{"name": "c", "image": "busybox"}]}
+                    }
+                }
+            }
+        ]
+    }"#;
+    assert_roundtrip::<List<ReplicaSet>>(fixture);
+}
+
+#[test]
+fn roundtrip_replicaset_zero_replicas() {
+    // Edge case: explicit zero replicas (paused/scaled-down RS).
+    let fixture = r#"{
+        "kind": "ReplicaSet",
+        "apiVersion": "apps/v1",
+        "metadata": {"name": "scaled-to-zero", "namespace": "default"},
+        "spec": {
+            "replicas": 0,
+            "selector": {"matchLabels": {"app": "scaled-to-zero"}},
+            "template": {
+                "metadata": {"labels": {"app": "scaled-to-zero"}},
+                "spec": {"containers": [{"name": "c", "image": "busybox"}]}
+            }
+        }
+    }"#;
+    assert_roundtrip::<ReplicaSet>(fixture);
+}
+
+// ---------------------------------------------------------------------------
+// StatefulSet fixtures
+// ---------------------------------------------------------------------------
+
+#[test]
+fn roundtrip_statefulset_minimal() {
+    let fixture = r#"{
+        "kind": "StatefulSet",
+        "apiVersion": "apps/v1",
+        "metadata": {"name": "web", "namespace": "default"},
+        "spec": {
+            "serviceName": "web",
+            "selector": {"matchLabels": {"app": "web"}},
+            "template": {
+                "metadata": {"labels": {"app": "web"}},
+                "spec": {"containers": [{"name": "nginx", "image": "nginx:1.25"}]}
+            }
+        }
+    }"#;
+    assert_roundtrip::<StatefulSet>(fixture);
+}
+
+#[test]
+fn roundtrip_statefulset_full_featured() {
+    let fixture = r#"{
+        "kind": "StatefulSet",
+        "apiVersion": "apps/v1",
+        "metadata": {
+            "name": "etcd",
+            "namespace": "kube-system",
+            "labels": {"app": "etcd"},
+            "generation": 2
+        },
+        "spec": {
+            "replicas": 3,
+            "serviceName": "etcd",
+            "podManagementPolicy": "Parallel",
+            "selector": {"matchLabels": {"app": "etcd"}},
+            "template": {
+                "metadata": {"labels": {"app": "etcd"}},
+                "spec": {
+                    "containers": [{
+                        "name": "etcd",
+                        "image": "quay.io/coreos/etcd:v3.5.0",
+                        "volumeMounts": [{"name": "data", "mountPath": "/var/lib/etcd"}]
+                    }]
+                }
+            },
+            "updateStrategy": {
+                "type": "RollingUpdate",
+                "rollingUpdate": {"partition": 0, "maxUnavailable": "1"}
+            },
+            "minReadySeconds": 10,
+            "revisionHistoryLimit": 10,
+            "persistentVolumeClaimRetentionPolicy": {
+                "whenDeleted": "Retain",
+                "whenScaled": "Delete"
+            },
+            "ordinals": {"start": 0}
+        },
+        "status": {
+            "replicas": 3,
+            "readyReplicas": 3,
+            "currentReplicas": 3,
+            "updatedReplicas": 3,
+            "availableReplicas": 3,
+            "collisionCount": 0,
+            "observedGeneration": 2,
+            "currentRevision": "etcd-7f9c4b5d8c",
+            "updateRevision": "etcd-7f9c4b5d8c"
+        }
+    }"#;
+    assert_roundtrip::<StatefulSet>(fixture);
+}
+
+#[test]
+fn roundtrip_statefulset_on_delete_strategy() {
+    let fixture = r#"{
+        "kind": "StatefulSet",
+        "apiVersion": "apps/v1",
+        "metadata": {"name": "manual", "namespace": "default"},
+        "spec": {
+            "serviceName": "manual",
+            "selector": {"matchLabels": {"app": "manual"}},
+            "template": {
+                "metadata": {"labels": {"app": "manual"}},
+                "spec": {"containers": [{"name": "c", "image": "busybox"}]}
+            },
+            "updateStrategy": {"type": "OnDelete"}
+        }
+    }"#;
+    assert_roundtrip::<StatefulSet>(fixture);
+}
+
+#[test]
+fn roundtrip_statefulset_status_subresource() {
+    let fixture = r#"{
+        "kind": "StatefulSet",
+        "apiVersion": "apps/v1",
+        "metadata": {"name": "sts-status", "namespace": "default"},
+        "spec": {
+            "serviceName": "sts-status",
+            "selector": {"matchLabels": {"app": "sts-status"}},
+            "template": {
+                "metadata": {"labels": {"app": "sts-status"}},
+                "spec": {"containers": [{"name": "c", "image": "busybox"}]}
+            }
+        },
+        "status": {
+            "replicas": 3,
+            "conditions": [
+                {
+                    "type": "Available",
+                    "status": "True",
+                    "reason": "MinimumReplicasAvailable",
+                    "message": "StatefulSet has minimum availability"
+                }
+            ]
+        }
+    }"#;
+    assert_roundtrip::<StatefulSet>(fixture);
+}
+
+#[test]
+fn roundtrip_statefulset_list_wrapper() {
+    let fixture = r#"{
+        "kind": "StatefulSetList",
+        "apiVersion": "apps/v1",
+        "metadata": {"resourceVersion": "777"},
+        "items": [
+            {
+                "kind": "StatefulSet",
+                "apiVersion": "apps/v1",
+                "metadata": {"name": "sts1", "namespace": "default"},
+                "spec": {
+                    "serviceName": "sts1",
+                    "selector": {"matchLabels": {"app": "sts1"}},
+                    "template": {
+                        "metadata": {"labels": {"app": "sts1"}},
+                        "spec": {"containers": [{"name": "c", "image": "busybox"}]}
+                    }
+                }
+            }
+        ]
+    }"#;
+    assert_roundtrip::<List<StatefulSet>>(fixture);
+}
+
+// ---------------------------------------------------------------------------
+// DaemonSet fixtures
+// ---------------------------------------------------------------------------
+
+#[test]
+fn roundtrip_daemonset_minimal() {
+    let fixture = r#"{
+        "kind": "DaemonSet",
+        "apiVersion": "apps/v1",
+        "metadata": {"name": "fluentd", "namespace": "kube-system"},
+        "spec": {
+            "selector": {"matchLabels": {"app": "fluentd"}},
+            "template": {
+                "metadata": {"labels": {"app": "fluentd"}},
+                "spec": {"containers": [{"name": "fluentd", "image": "fluent/fluentd:v1.16"}]}
+            }
+        }
+    }"#;
+    assert_roundtrip::<DaemonSet>(fixture);
+}
+
+#[test]
+fn roundtrip_daemonset_full_featured() {
+    let fixture = r#"{
+        "kind": "DaemonSet",
+        "apiVersion": "apps/v1",
+        "metadata": {
+            "name": "node-exporter",
+            "namespace": "monitoring",
+            "labels": {"app": "node-exporter"}
+        },
+        "spec": {
+            "selector": {"matchLabels": {"app": "node-exporter"}},
+            "template": {
+                "metadata": {"labels": {"app": "node-exporter"}},
+                "spec": {
+                    "hostNetwork": true,
+                    "hostPID": true,
+                    "containers": [{
+                        "name": "node-exporter",
+                        "image": "prom/node-exporter:v1.7.0",
+                        "ports": [{"containerPort": 9100, "name": "metrics", "protocol": "TCP"}]
+                    }],
+                    "tolerations": [
+                        {"operator": "Exists"}
+                    ]
+                }
+            },
+            "updateStrategy": {
+                "type": "RollingUpdate",
+                "rollingUpdate": {"maxUnavailable": "10%", "maxSurge": "0"}
+            },
+            "minReadySeconds": 5,
+            "revisionHistoryLimit": 10
+        },
+        "status": {
+            "desiredNumberScheduled": 3,
+            "currentNumberScheduled": 3,
+            "numberReady": 3,
+            "numberMisscheduled": 0,
+            "numberAvailable": 3,
+            "numberUnavailable": 0,
+            "updatedNumberScheduled": 3,
+            "observedGeneration": 1,
+            "collisionCount": 0
+        }
+    }"#;
+    assert_roundtrip::<DaemonSet>(fixture);
+}
+
+#[test]
+fn roundtrip_daemonset_status_subresource() {
+    let fixture = r#"{
+        "kind": "DaemonSet",
+        "apiVersion": "apps/v1",
+        "metadata": {"name": "ds-status", "namespace": "default"},
+        "spec": {
+            "selector": {"matchLabels": {"app": "ds-status"}},
+            "template": {
+                "metadata": {"labels": {"app": "ds-status"}},
+                "spec": {"containers": [{"name": "c", "image": "busybox"}]}
+            }
+        },
+        "status": {
+            "desiredNumberScheduled": 5,
+            "currentNumberScheduled": 4,
+            "numberReady": 3,
+            "numberMisscheduled": 1,
+            "conditions": [
+                {"type": "Progressing", "status": "True"}
+            ]
+        }
+    }"#;
+    assert_roundtrip::<DaemonSet>(fixture);
+}
+
+#[test]
+fn roundtrip_daemonset_on_delete_strategy() {
+    let fixture = r#"{
+        "kind": "DaemonSet",
+        "apiVersion": "apps/v1",
+        "metadata": {"name": "ondelete-ds", "namespace": "default"},
+        "spec": {
+            "selector": {"matchLabels": {"app": "ondelete-ds"}},
+            "template": {
+                "metadata": {"labels": {"app": "ondelete-ds"}},
+                "spec": {"containers": [{"name": "c", "image": "busybox"}]}
+            },
+            "updateStrategy": {"type": "OnDelete"}
+        }
+    }"#;
+    assert_roundtrip::<DaemonSet>(fixture);
+}
+
+#[test]
+fn roundtrip_daemonset_list_wrapper() {
+    let fixture = r#"{
+        "kind": "DaemonSetList",
+        "apiVersion": "apps/v1",
+        "metadata": {"resourceVersion": "42"},
+        "items": [
+            {
+                "kind": "DaemonSet",
+                "apiVersion": "apps/v1",
+                "metadata": {"name": "ds-a", "namespace": "default"},
+                "spec": {
+                    "selector": {"matchLabels": {"app": "ds-a"}},
+                    "template": {
+                        "metadata": {"labels": {"app": "ds-a"}},
+                        "spec": {"containers": [{"name": "c", "image": "busybox"}]}
+                    }
+                }
+            }
+        ]
+    }"#;
+    assert_roundtrip::<List<DaemonSet>>(fixture);
+}
+
+// ---------------------------------------------------------------------------
+// ControllerRevision fixtures
+// ---------------------------------------------------------------------------
+
+#[test]
+fn roundtrip_controller_revision_minimal() {
+    let fixture = r#"{
+        "kind": "ControllerRevision",
+        "apiVersion": "apps/v1",
+        "metadata": {"name": "rev-1", "namespace": "default"},
+        "revision": 1
+    }"#;
+    assert_roundtrip::<ControllerRevision>(fixture);
+}
+
+#[test]
+fn roundtrip_controller_revision_with_data() {
+    // Mirrors what StatefulSet/DaemonSet controllers persist: an opaque
+    // serialized snapshot under `data`.
+    let fixture = r#"{
+        "kind": "ControllerRevision",
+        "apiVersion": "apps/v1",
+        "metadata": {
+            "name": "web-7c5b8f9d6",
+            "namespace": "default",
+            "labels": {
+                "app": "web",
+                "controller-revision-hash": "7c5b8f9d6"
+            }
+        },
+        "data": {
+            "spec": {
+                "template": {
+                    "metadata": {"labels": {"app": "web"}},
+                    "spec": {"containers": [{"name": "web", "image": "nginx:1.25"}]}
+                }
+            }
+        },
+        "revision": 3
+    }"#;
+    assert_roundtrip::<ControllerRevision>(fixture);
+}
+
+#[test]
+fn roundtrip_controller_revision_owned_by_statefulset() {
+    let fixture = r#"{
+        "kind": "ControllerRevision",
+        "apiVersion": "apps/v1",
+        "metadata": {
+            "name": "etcd-abc123",
+            "namespace": "kube-system",
+            "ownerReferences": [{
+                "apiVersion": "apps/v1",
+                "kind": "StatefulSet",
+                "name": "etcd",
+                "uid": "deadbeef-1234",
+                "controller": true,
+                "blockOwnerDeletion": true
+            }]
+        },
+        "revision": 7,
+        "data": {"key": "value"}
+    }"#;
+    assert_roundtrip::<ControllerRevision>(fixture);
+}
+
+#[test]
+fn roundtrip_controller_revision_large_revision_number() {
+    // Edge case: revision is i64; verify large numbers roundtrip without
+    // narrowing.
+    let fixture = r#"{
+        "kind": "ControllerRevision",
+        "apiVersion": "apps/v1",
+        "metadata": {"name": "big-rev", "namespace": "default"},
+        "revision": 9223372036854775807
+    }"#;
+    assert_roundtrip::<ControllerRevision>(fixture);
+}
+
+#[test]
+fn roundtrip_controller_revision_list_wrapper() {
+    let fixture = r#"{
+        "kind": "ControllerRevisionList",
+        "apiVersion": "apps/v1",
+        "metadata": {"resourceVersion": "100"},
+        "items": [
+            {
+                "kind": "ControllerRevision",
+                "apiVersion": "apps/v1",
+                "metadata": {"name": "rev-1", "namespace": "default"},
+                "revision": 1
+            },
+            {
+                "kind": "ControllerRevision",
+                "apiVersion": "apps/v1",
+                "metadata": {"name": "rev-2", "namespace": "default"},
+                "revision": 2,
+                "data": {"foo": "bar"}
+            }
+        ]
+    }"#;
+    assert_roundtrip::<List<ControllerRevision>>(fixture);
+}

--- a/crates/common/tests/roundtrip_batch.rs
+++ b/crates/common/tests/roundtrip_batch.rs
@@ -1,0 +1,782 @@
+// JSON roundtrip tests for batch/v1, autoscaling/v1, autoscaling/v2, and
+// policy/v1 resources.
+//
+// These tests mirror the roundtrip serialization layer that upstream
+// kube-apiserver runs against every external API type (k8s.io/api/<group>/v1).
+// For each fixture we assert:
+//
+//   1. decode succeeds:   T::deserialize(fixture)
+//   2. re-encode succeeds: serde_json::to_string(&decoded)
+//   3. re-decode succeeds: T::deserialize(re_encoded)
+//   4. roundtrip stable:   serde_json::Value(decoded) == Value(re_decoded)
+//
+// We compare via `serde_json::Value` because the resource structs do not
+// implement `PartialEq` (mirroring upstream Go, where equality is checked at
+// the wire level rather than struct level).
+//
+// The fixtures intentionally cover both the autoscaling/v1 (simple CPU-target)
+// HPA shape and the autoscaling/v2 (multi-metric + behavior) HPA shape, which
+// share the same Rust struct in this codebase but have very different JSON.
+
+use rusternetes_common::resources::{
+    CronJob, HorizontalPodAutoscaler, IntOrString, Job, PodDisruptionBudget,
+};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+/// Runs the four-step roundtrip check for a single fixture and returns the
+/// decoded value so callers can perform additional field-level assertions.
+fn assert_roundtrip<T>(fixture: &str) -> T
+where
+    T: DeserializeOwned + Serialize,
+{
+    let decoded: T = serde_json::from_str(fixture)
+        .unwrap_or_else(|e| panic!("step 1 (decode) failed: {e}\nfixture: {fixture}"));
+
+    let re_encoded =
+        serde_json::to_string(&decoded).unwrap_or_else(|e| panic!("step 2 (encode) failed: {e}"));
+
+    let re_decoded: T = serde_json::from_str(&re_encoded)
+        .unwrap_or_else(|e| panic!("step 3 (re-decode) failed: {e}\nre-encoded: {re_encoded}"));
+
+    let lhs: serde_json::Value =
+        serde_json::to_value(&decoded).expect("decoded -> Value must succeed");
+    let rhs: serde_json::Value =
+        serde_json::to_value(&re_decoded).expect("re_decoded -> Value must succeed");
+    assert_eq!(
+        lhs, rhs,
+        "step 4 (roundtrip stability) failed\nlhs: {lhs}\nrhs: {rhs}"
+    );
+
+    decoded
+}
+
+// ---------------------------------------------------------------------------
+// batch/v1 — Job
+// ---------------------------------------------------------------------------
+
+#[test]
+fn roundtrip_job_minimal_spec() {
+    let fixture = r#"{
+      "apiVersion": "batch/v1",
+      "kind": "Job",
+      "metadata": {"name": "pi", "namespace": "default"},
+      "spec": {
+        "template": {
+          "spec": {
+            "containers": [{"name": "pi", "image": "perl:5.34"}],
+            "restartPolicy": "Never"
+          }
+        }
+      }
+    }"#;
+    let job: Job = assert_roundtrip(fixture);
+    assert_eq!(job.metadata.name, "pi");
+    assert_eq!(job.type_meta.api_version, "batch/v1");
+    assert_eq!(job.spec.template.spec.containers.len(), 1);
+}
+
+#[test]
+fn roundtrip_job_with_parallelism_and_completions() {
+    let fixture = r#"{
+      "apiVersion": "batch/v1",
+      "kind": "Job",
+      "metadata": {"name": "parallel", "namespace": "batch"},
+      "spec": {
+        "parallelism": 4,
+        "completions": 8,
+        "backoffLimit": 6,
+        "activeDeadlineSeconds": 300,
+        "template": {
+          "spec": {
+            "containers": [{"name": "worker", "image": "busybox:1.36"}],
+            "restartPolicy": "OnFailure"
+          }
+        }
+      }
+    }"#;
+    let job: Job = assert_roundtrip(fixture);
+    assert_eq!(job.spec.parallelism, Some(4));
+    assert_eq!(job.spec.completions, Some(8));
+    assert_eq!(job.spec.backoff_limit, Some(6));
+    assert_eq!(job.spec.active_deadline_seconds, Some(300));
+}
+
+#[test]
+fn roundtrip_job_indexed_completion_mode() {
+    let fixture = r#"{
+      "apiVersion": "batch/v1",
+      "kind": "Job",
+      "metadata": {"name": "indexed", "namespace": "default"},
+      "spec": {
+        "completions": 10,
+        "parallelism": 5,
+        "completionMode": "Indexed",
+        "backoffLimitPerIndex": 2,
+        "maxFailedIndexes": 3,
+        "template": {
+          "spec": {
+            "containers": [{"name": "shard", "image": "alpine:3.20"}],
+            "restartPolicy": "Never"
+          }
+        }
+      }
+    }"#;
+    let job: Job = assert_roundtrip(fixture);
+    assert_eq!(job.spec.completion_mode.as_deref(), Some("Indexed"));
+    assert_eq!(job.spec.backoff_limit_per_index, Some(2));
+    assert_eq!(job.spec.max_failed_indexes, Some(3));
+}
+
+#[test]
+fn roundtrip_job_with_selector_and_manual_selector() {
+    let fixture = r#"{
+      "apiVersion": "batch/v1",
+      "kind": "Job",
+      "metadata": {"name": "manual-sel", "namespace": "default"},
+      "spec": {
+        "manualSelector": true,
+        "selector": {
+          "matchLabels": {"controller-uid": "abc-123"}
+        },
+        "template": {
+          "metadata": {"labels": {"controller-uid": "abc-123"}},
+          "spec": {
+            "containers": [{"name": "x", "image": "busybox"}],
+            "restartPolicy": "Never"
+          }
+        }
+      }
+    }"#;
+    let job: Job = assert_roundtrip(fixture);
+    assert_eq!(job.spec.manual_selector, Some(true));
+    assert!(job.spec.selector.is_some());
+}
+
+#[test]
+fn roundtrip_job_suspended_with_ttl() {
+    let fixture = r#"{
+      "apiVersion": "batch/v1",
+      "kind": "Job",
+      "metadata": {"name": "suspended", "namespace": "default"},
+      "spec": {
+        "suspend": true,
+        "ttlSecondsAfterFinished": 600,
+        "podReplacementPolicy": "Failed",
+        "template": {
+          "spec": {
+            "containers": [{"name": "x", "image": "busybox"}],
+            "restartPolicy": "Never"
+          }
+        }
+      }
+    }"#;
+    let job: Job = assert_roundtrip(fixture);
+    assert_eq!(job.spec.suspend, Some(true));
+    assert_eq!(job.spec.ttl_seconds_after_finished, Some(600));
+    assert_eq!(job.spec.pod_replacement_policy.as_deref(), Some("Failed"));
+}
+
+#[test]
+fn roundtrip_job_with_status() {
+    let fixture = r#"{
+      "apiVersion": "batch/v1",
+      "kind": "Job",
+      "metadata": {"name": "running", "namespace": "default"},
+      "spec": {
+        "template": {
+          "spec": {
+            "containers": [{"name": "x", "image": "busybox"}],
+            "restartPolicy": "Never"
+          }
+        }
+      },
+      "status": {
+        "active": 2,
+        "succeeded": 3,
+        "failed": 1,
+        "ready": 2,
+        "terminating": 0,
+        "startTime": "2024-01-01T00:00:00Z",
+        "conditions": [
+          {"type": "Complete", "status": "False"}
+        ]
+      }
+    }"#;
+    let job: Job = assert_roundtrip(fixture);
+    let status = job.status.expect("status present");
+    assert_eq!(status.active, Some(2));
+    assert_eq!(status.succeeded, Some(3));
+    assert_eq!(status.failed, Some(1));
+}
+
+// ---------------------------------------------------------------------------
+// batch/v1 — CronJob
+// ---------------------------------------------------------------------------
+
+#[test]
+fn roundtrip_cronjob_minimal() {
+    let fixture = r#"{
+      "apiVersion": "batch/v1",
+      "kind": "CronJob",
+      "metadata": {"name": "hello", "namespace": "default"},
+      "spec": {
+        "schedule": "* * * * *",
+        "jobTemplate": {
+          "spec": {
+            "template": {
+              "spec": {
+                "containers": [{"name": "hello", "image": "busybox"}],
+                "restartPolicy": "OnFailure"
+              }
+            }
+          }
+        }
+      }
+    }"#;
+    let cj: CronJob = assert_roundtrip(fixture);
+    assert_eq!(cj.spec.schedule, "* * * * *");
+    assert_eq!(cj.type_meta.api_version, "batch/v1");
+}
+
+#[test]
+fn roundtrip_cronjob_with_history_and_concurrency() {
+    let fixture = r#"{
+      "apiVersion": "batch/v1",
+      "kind": "CronJob",
+      "metadata": {"name": "every-hour", "namespace": "ops"},
+      "spec": {
+        "schedule": "0 * * * *",
+        "concurrencyPolicy": "Forbid",
+        "suspend": false,
+        "successfulJobsHistoryLimit": 3,
+        "failedJobsHistoryLimit": 1,
+        "startingDeadlineSeconds": 200,
+        "jobTemplate": {
+          "spec": {
+            "template": {
+              "spec": {
+                "containers": [{"name": "task", "image": "alpine"}],
+                "restartPolicy": "OnFailure"
+              }
+            }
+          }
+        }
+      }
+    }"#;
+    let cj: CronJob = assert_roundtrip(fixture);
+    assert_eq!(cj.spec.concurrency_policy.as_deref(), Some("Forbid"));
+    assert_eq!(cj.spec.successful_jobs_history_limit, Some(3));
+    assert_eq!(cj.spec.failed_jobs_history_limit, Some(1));
+    assert_eq!(cj.spec.starting_deadline_seconds, Some(200));
+}
+
+#[test]
+fn roundtrip_cronjob_with_timezone() {
+    let fixture = r#"{
+      "apiVersion": "batch/v1",
+      "kind": "CronJob",
+      "metadata": {"name": "ny-tz", "namespace": "default"},
+      "spec": {
+        "schedule": "0 9 * * 1-5",
+        "timeZone": "America/New_York",
+        "concurrencyPolicy": "Replace",
+        "jobTemplate": {
+          "spec": {
+            "template": {
+              "spec": {
+                "containers": [{"name": "x", "image": "busybox"}],
+                "restartPolicy": "Never"
+              }
+            }
+          }
+        }
+      }
+    }"#;
+    let cj: CronJob = assert_roundtrip(fixture);
+    assert_eq!(cj.spec.time_zone.as_deref(), Some("America/New_York"));
+    assert_eq!(cj.spec.concurrency_policy.as_deref(), Some("Replace"));
+}
+
+#[test]
+fn roundtrip_cronjob_suspended() {
+    let fixture = r#"{
+      "apiVersion": "batch/v1",
+      "kind": "CronJob",
+      "metadata": {"name": "paused", "namespace": "default"},
+      "spec": {
+        "schedule": "@daily",
+        "suspend": true,
+        "jobTemplate": {
+          "spec": {
+            "template": {
+              "spec": {
+                "containers": [{"name": "x", "image": "busybox"}],
+                "restartPolicy": "Never"
+              }
+            }
+          }
+        }
+      }
+    }"#;
+    let cj: CronJob = assert_roundtrip(fixture);
+    assert_eq!(cj.spec.suspend, Some(true));
+}
+
+#[test]
+fn roundtrip_cronjob_with_status_active_and_times() {
+    let fixture = r#"{
+      "apiVersion": "batch/v1",
+      "kind": "CronJob",
+      "metadata": {"name": "with-status", "namespace": "default"},
+      "spec": {
+        "schedule": "*/5 * * * *",
+        "jobTemplate": {
+          "spec": {
+            "template": {
+              "spec": {
+                "containers": [{"name": "x", "image": "busybox"}],
+                "restartPolicy": "Never"
+              }
+            }
+          }
+        }
+      },
+      "status": {
+        "active": [
+          {"kind": "Job", "name": "with-status-12345", "namespace": "default", "uid": "deadbeef"}
+        ],
+        "lastScheduleTime": "2024-06-01T12:00:00Z",
+        "lastSuccessfulTime": "2024-06-01T11:55:00Z"
+      }
+    }"#;
+    let cj: CronJob = assert_roundtrip(fixture);
+    let status = cj.status.expect("status present");
+    assert_eq!(status.active.len(), 1);
+    assert!(status.last_schedule_time.is_some());
+    assert!(status.last_successful_time.is_some());
+}
+
+// ---------------------------------------------------------------------------
+// autoscaling/v1 — HorizontalPodAutoscaler (simple CPU target)
+//
+// One struct backs both autoscaling/v1 and autoscaling/v2 in this codebase, so
+// the v1-specific `targetCPUUtilizationPercentage` field is silently dropped
+// by serde. These fixtures verify that the fields the struct *does* model
+// (scaleTargetRef + min/max + apiVersion) round-trip stably from a v1 payload.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn roundtrip_hpa_v1_simple_cpu_target() {
+    let fixture = r#"{
+      "apiVersion": "autoscaling/v1",
+      "kind": "HorizontalPodAutoscaler",
+      "metadata": {"name": "frontend", "namespace": "default"},
+      "spec": {
+        "scaleTargetRef": {
+          "kind": "Deployment",
+          "name": "frontend",
+          "apiVersion": "apps/v1"
+        },
+        "minReplicas": 1,
+        "maxReplicas": 10
+      }
+    }"#;
+    let hpa: HorizontalPodAutoscaler = assert_roundtrip(fixture);
+    assert_eq!(hpa.type_meta.api_version, "autoscaling/v1");
+    assert_eq!(hpa.spec.scale_target_ref.kind, "Deployment");
+    assert_eq!(hpa.spec.min_replicas, Some(1));
+    assert_eq!(hpa.spec.max_replicas, 10);
+}
+
+#[test]
+fn roundtrip_hpa_v1_no_min_replicas() {
+    let fixture = r#"{
+      "apiVersion": "autoscaling/v1",
+      "kind": "HorizontalPodAutoscaler",
+      "metadata": {"name": "no-min", "namespace": "default"},
+      "spec": {
+        "scaleTargetRef": {"kind": "Deployment", "name": "no-min"},
+        "maxReplicas": 5
+      }
+    }"#;
+    let hpa: HorizontalPodAutoscaler = assert_roundtrip(fixture);
+    assert_eq!(hpa.spec.min_replicas, None);
+    assert_eq!(hpa.spec.max_replicas, 5);
+    assert!(hpa.spec.scale_target_ref.api_version.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// autoscaling/v2 — HorizontalPodAutoscaler (multi-metric + behavior)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn roundtrip_hpa_v2_resource_metric_cpu_utilization() {
+    let fixture = r#"{
+      "apiVersion": "autoscaling/v2",
+      "kind": "HorizontalPodAutoscaler",
+      "metadata": {"name": "cpu-hpa", "namespace": "default"},
+      "spec": {
+        "scaleTargetRef": {
+          "kind": "Deployment",
+          "name": "web",
+          "apiVersion": "apps/v1"
+        },
+        "minReplicas": 2,
+        "maxReplicas": 20,
+        "metrics": [
+          {
+            "type": "Resource",
+            "resource": {
+              "name": "cpu",
+              "target": {"type": "Utilization", "averageUtilization": 70}
+            }
+          }
+        ]
+      }
+    }"#;
+    let hpa: HorizontalPodAutoscaler = assert_roundtrip(fixture);
+    assert_eq!(hpa.type_meta.api_version, "autoscaling/v2");
+    let metrics = hpa.spec.metrics.expect("metrics present");
+    assert_eq!(metrics.len(), 1);
+    assert_eq!(metrics[0].metric_type, "Resource");
+}
+
+#[test]
+fn roundtrip_hpa_v2_multi_metric_pods_and_external() {
+    let fixture = r#"{
+      "apiVersion": "autoscaling/v2",
+      "kind": "HorizontalPodAutoscaler",
+      "metadata": {"name": "multi", "namespace": "default"},
+      "spec": {
+        "scaleTargetRef": {"kind": "Deployment", "name": "multi", "apiVersion": "apps/v1"},
+        "minReplicas": 1,
+        "maxReplicas": 50,
+        "metrics": [
+          {
+            "type": "Pods",
+            "pods": {
+              "metric": {"name": "packets-per-second"},
+              "target": {"type": "AverageValue", "averageValue": "1k"}
+            }
+          },
+          {
+            "type": "External",
+            "external": {
+              "metric": {
+                "name": "queue_messages_ready",
+                "selector": {"matchLabels": {"queue": "worker_tasks"}}
+              },
+              "target": {"type": "AverageValue", "averageValue": "30"}
+            }
+          }
+        ]
+      }
+    }"#;
+    let hpa: HorizontalPodAutoscaler = assert_roundtrip(fixture);
+    let metrics = hpa.spec.metrics.expect("metrics present");
+    assert_eq!(metrics.len(), 2);
+    assert_eq!(metrics[0].metric_type, "Pods");
+    assert_eq!(metrics[1].metric_type, "External");
+}
+
+#[test]
+fn roundtrip_hpa_v2_object_metric() {
+    let fixture = r#"{
+      "apiVersion": "autoscaling/v2",
+      "kind": "HorizontalPodAutoscaler",
+      "metadata": {"name": "object", "namespace": "default"},
+      "spec": {
+        "scaleTargetRef": {"kind": "Deployment", "name": "ingress", "apiVersion": "apps/v1"},
+        "maxReplicas": 10,
+        "metrics": [
+          {
+            "type": "Object",
+            "object": {
+              "describedObject": {
+                "kind": "Ingress",
+                "name": "main-route",
+                "apiVersion": "networking.k8s.io/v1"
+              },
+              "metric": {"name": "requests-per-second"},
+              "target": {"type": "Value", "value": "10k"}
+            }
+          }
+        ]
+      }
+    }"#;
+    let hpa: HorizontalPodAutoscaler = assert_roundtrip(fixture);
+    let metrics = hpa.spec.metrics.expect("metrics present");
+    assert_eq!(metrics[0].metric_type, "Object");
+    let object = metrics[0].object.as_ref().expect("object metric present");
+    assert_eq!(object.described_object.kind, "Ingress");
+}
+
+#[test]
+fn roundtrip_hpa_v2_container_resource_metric() {
+    let fixture = r#"{
+      "apiVersion": "autoscaling/v2",
+      "kind": "HorizontalPodAutoscaler",
+      "metadata": {"name": "container", "namespace": "default"},
+      "spec": {
+        "scaleTargetRef": {"kind": "Deployment", "name": "container", "apiVersion": "apps/v1"},
+        "minReplicas": 1,
+        "maxReplicas": 5,
+        "metrics": [
+          {
+            "type": "ContainerResource",
+            "containerResource": {
+              "name": "memory",
+              "container": "app",
+              "target": {"type": "Utilization", "averageUtilization": 80}
+            }
+          }
+        ]
+      }
+    }"#;
+    let hpa: HorizontalPodAutoscaler = assert_roundtrip(fixture);
+    let metrics = hpa.spec.metrics.expect("metrics present");
+    assert_eq!(metrics[0].metric_type, "ContainerResource");
+    let cr = metrics[0]
+        .container_resource
+        .as_ref()
+        .expect("containerResource present");
+    assert_eq!(cr.container, "app");
+    assert_eq!(cr.name, "memory");
+}
+
+#[test]
+fn roundtrip_hpa_v2_with_behavior() {
+    let fixture = r#"{
+      "apiVersion": "autoscaling/v2",
+      "kind": "HorizontalPodAutoscaler",
+      "metadata": {"name": "behavior", "namespace": "default"},
+      "spec": {
+        "scaleTargetRef": {"kind": "Deployment", "name": "behavior", "apiVersion": "apps/v1"},
+        "minReplicas": 1,
+        "maxReplicas": 100,
+        "metrics": [
+          {
+            "type": "Resource",
+            "resource": {
+              "name": "cpu",
+              "target": {"type": "Utilization", "averageUtilization": 50}
+            }
+          }
+        ],
+        "behavior": {
+          "scaleDown": {
+            "stabilizationWindowSeconds": 300,
+            "selectPolicy": "Min",
+            "policies": [
+              {"type": "Pods", "value": 4, "periodSeconds": 60},
+              {"type": "Percent", "value": 10, "periodSeconds": 60}
+            ]
+          },
+          "scaleUp": {
+            "stabilizationWindowSeconds": 0,
+            "selectPolicy": "Max",
+            "policies": [
+              {"type": "Percent", "value": 100, "periodSeconds": 15}
+            ]
+          }
+        }
+      }
+    }"#;
+    let hpa: HorizontalPodAutoscaler = assert_roundtrip(fixture);
+    let behavior = hpa.spec.behavior.expect("behavior present");
+    let scale_down = behavior.scale_down.expect("scaleDown present");
+    assert_eq!(scale_down.stabilization_window_seconds, Some(300));
+    assert_eq!(scale_down.select_policy.as_deref(), Some("Min"));
+    let policies = scale_down.policies.expect("policies present");
+    assert_eq!(policies.len(), 2);
+    let scale_up = behavior.scale_up.expect("scaleUp present");
+    assert_eq!(scale_up.select_policy.as_deref(), Some("Max"));
+}
+
+#[test]
+fn roundtrip_hpa_v2_with_status_and_conditions() {
+    let fixture = r#"{
+      "apiVersion": "autoscaling/v2",
+      "kind": "HorizontalPodAutoscaler",
+      "metadata": {"name": "status", "namespace": "default"},
+      "spec": {
+        "scaleTargetRef": {"kind": "Deployment", "name": "status", "apiVersion": "apps/v1"},
+        "minReplicas": 1,
+        "maxReplicas": 10,
+        "metrics": [
+          {
+            "type": "Resource",
+            "resource": {
+              "name": "cpu",
+              "target": {"type": "Utilization", "averageUtilization": 70}
+            }
+          }
+        ]
+      },
+      "status": {
+        "observedGeneration": 1,
+        "lastScaleTime": "2024-06-01T00:00:00Z",
+        "currentReplicas": 3,
+        "desiredReplicas": 5,
+        "currentMetrics": [
+          {
+            "type": "Resource",
+            "resource": {
+              "name": "cpu",
+              "current": {"averageUtilization": 65, "averageValue": "650m"}
+            }
+          }
+        ],
+        "conditions": [
+          {
+            "type": "AbleToScale",
+            "status": "True",
+            "lastTransitionTime": "2024-06-01T00:00:00Z",
+            "reason": "ReadyForNewScale",
+            "message": "recommended size matches current size"
+          }
+        ]
+      }
+    }"#;
+    let hpa: HorizontalPodAutoscaler = assert_roundtrip(fixture);
+    let status = hpa.status.expect("status present");
+    assert_eq!(status.current_replicas, 3);
+    assert_eq!(status.desired_replicas, 5);
+    assert_eq!(status.observed_generation, Some(1));
+    let conditions = status.conditions.expect("conditions present");
+    assert_eq!(conditions.len(), 1);
+    assert_eq!(conditions[0].condition_type, "AbleToScale");
+}
+
+// ---------------------------------------------------------------------------
+// policy/v1 — PodDisruptionBudget
+// ---------------------------------------------------------------------------
+
+#[test]
+fn roundtrip_pdb_min_available_int() {
+    let fixture = r#"{
+      "apiVersion": "policy/v1",
+      "kind": "PodDisruptionBudget",
+      "metadata": {"name": "web-pdb", "namespace": "default"},
+      "spec": {
+        "minAvailable": 2,
+        "selector": {"matchLabels": {"app": "web"}}
+      }
+    }"#;
+    let pdb: PodDisruptionBudget = assert_roundtrip(fixture);
+    assert_eq!(pdb.type_meta.api_version, "policy/v1");
+    match pdb.spec.min_available {
+        Some(IntOrString::Int(n)) => assert_eq!(n, 2),
+        other => panic!("expected Int(2), got {:?}", other),
+    }
+}
+
+#[test]
+fn roundtrip_pdb_max_unavailable_percent() {
+    let fixture = r#"{
+      "apiVersion": "policy/v1",
+      "kind": "PodDisruptionBudget",
+      "metadata": {"name": "db-pdb", "namespace": "production"},
+      "spec": {
+        "maxUnavailable": "25%",
+        "selector": {"matchLabels": {"app": "database"}}
+      }
+    }"#;
+    let pdb: PodDisruptionBudget = assert_roundtrip(fixture);
+    match pdb.spec.max_unavailable {
+        Some(IntOrString::String(ref s)) => assert_eq!(s, "25%"),
+        ref other => panic!("expected String(\"25%\"), got {:?}", other),
+    }
+}
+
+#[test]
+fn roundtrip_pdb_with_match_expressions() {
+    let fixture = r#"{
+      "apiVersion": "policy/v1",
+      "kind": "PodDisruptionBudget",
+      "metadata": {"name": "expr-pdb", "namespace": "default"},
+      "spec": {
+        "minAvailable": 1,
+        "selector": {
+          "matchExpressions": [
+            {"key": "tier", "operator": "In", "values": ["frontend", "backend"]}
+          ]
+        }
+      }
+    }"#;
+    let pdb: PodDisruptionBudget = assert_roundtrip(fixture);
+    let exprs = pdb
+        .spec
+        .selector
+        .match_expressions
+        .expect("matchExpressions present");
+    assert_eq!(exprs.len(), 1);
+    assert_eq!(exprs[0].key, "tier");
+    assert_eq!(exprs[0].operator, "In");
+}
+
+#[test]
+fn roundtrip_pdb_unhealthy_pod_eviction_policy() {
+    let fixture = r#"{
+      "apiVersion": "policy/v1",
+      "kind": "PodDisruptionBudget",
+      "metadata": {"name": "evict", "namespace": "default"},
+      "spec": {
+        "minAvailable": 1,
+        "selector": {"matchLabels": {"app": "x"}},
+        "unhealthyPodEvictionPolicy": "AlwaysAllow"
+      }
+    }"#;
+    let pdb: PodDisruptionBudget = assert_roundtrip(fixture);
+    assert_eq!(
+        pdb.spec.unhealthy_pod_eviction_policy.as_deref(),
+        Some("AlwaysAllow"),
+    );
+}
+
+#[test]
+fn roundtrip_pdb_with_status() {
+    let fixture = r#"{
+      "apiVersion": "policy/v1",
+      "kind": "PodDisruptionBudget",
+      "metadata": {"name": "status-pdb", "namespace": "default"},
+      "spec": {
+        "minAvailable": 2,
+        "selector": {"matchLabels": {"app": "x"}}
+      },
+      "status": {
+        "currentHealthy": 3,
+        "desiredHealthy": 2,
+        "disruptionsAllowed": 1,
+        "expectedPods": 3,
+        "observedGeneration": 7
+      }
+    }"#;
+    let pdb: PodDisruptionBudget = assert_roundtrip(fixture);
+    let status = pdb.status.expect("status present");
+    assert_eq!(status.current_healthy, 3);
+    assert_eq!(status.desired_healthy, 2);
+    assert_eq!(status.disruptions_allowed, 1);
+    assert_eq!(status.expected_pods, 3);
+    assert_eq!(status.observed_generation, Some(7));
+}
+
+#[test]
+fn roundtrip_pdb_zero_max_unavailable_int() {
+    // maxUnavailable: 0 is a valid (and meaningful) PDB shape — block any voluntary disruption.
+    let fixture = r#"{
+      "apiVersion": "policy/v1",
+      "kind": "PodDisruptionBudget",
+      "metadata": {"name": "zero", "namespace": "default"},
+      "spec": {
+        "maxUnavailable": 0,
+        "selector": {"matchLabels": {"app": "critical"}}
+      }
+    }"#;
+    let pdb: PodDisruptionBudget = assert_roundtrip(fixture);
+    match pdb.spec.max_unavailable {
+        Some(IntOrString::Int(n)) => assert_eq!(n, 0),
+        other => panic!("expected Int(0), got {:?}", other),
+    }
+}

--- a/crates/common/tests/roundtrip_core_v1.rs
+++ b/crates/common/tests/roundtrip_core_v1.rs
@@ -1,0 +1,1293 @@
+//! JSON roundtrip tests for core/v1 resources.
+//!
+//! Mirrors the test layer at upstream
+//! `staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/` which
+//! verifies that every typed resource can survive a JSON encode -> decode ->
+//! encode -> decode cycle without mutation.
+//!
+//! For each resource we exercise representative payloads (minimal, full-
+//! featured, list wrapper, nested edge cases) and assert four things:
+//!
+//!   1. `serde_json::from_str::<T>(&fixture)` succeeds (initial decode)
+//!   2. `serde_json::to_string(&decoded)` succeeds (re-encode)
+//!   3. `serde_json::from_str::<T>(&re_encoded)` succeeds (second decode)
+//!   4. The two decoded values are equal -- comparing via `serde_json::Value`
+//!      because not every core/v1 struct derives `PartialEq` yet.
+//!
+//! The fixtures use the same camelCase wire format the api-server emits
+//! (`podIP`, `containerID`, `apiVersion`, etc.). This layer catches regressions
+//! at the serde boundary before any router/storage code is involved.
+
+use rusternetes_common::resources::{
+    ConfigMap, Endpoints, Event, LimitRange, Namespace, Node, PersistentVolume,
+    PersistentVolumeClaim, Pod, ResourceQuota, Secret, Service, ServiceAccount,
+};
+use serde::{de::DeserializeOwned, Serialize};
+
+/// Run the four-step roundtrip assertion for a typed payload.
+///
+/// 1. decode fixture -> `T`
+/// 2. encode `T` -> JSON
+/// 3. decode JSON -> `T`
+/// 4. compare the two decoded `T`s via their `serde_json::Value` projection
+///
+/// We compare as `Value` rather than via `PartialEq` because many core/v1
+/// structs (Pod, Service, Node, ...) don't currently derive `PartialEq` and
+/// the goal of the layer is to verify the *wire* shape survives -- that's
+/// exactly what Value-equality measures.
+fn assert_roundtrip<T>(fixture: &str)
+where
+    T: Serialize + DeserializeOwned,
+{
+    let decoded: T = serde_json::from_str(fixture)
+        .unwrap_or_else(|e| panic!("initial decode failed: {e}\nfixture: {fixture}"));
+    let re_encoded = serde_json::to_string(&decoded).expect("re-encode failed");
+    let re_decoded: T = serde_json::from_str(&re_encoded)
+        .unwrap_or_else(|e| panic!("second decode failed: {e}\nre_encoded: {re_encoded}"));
+
+    let decoded_value = serde_json::to_value(&decoded).expect("decoded -> Value");
+    let re_decoded_value = serde_json::to_value(&re_decoded).expect("re_decoded -> Value");
+    assert_eq!(
+        decoded_value, re_decoded_value,
+        "roundtrip not stable\nfirst:  {decoded_value}\nsecond: {re_decoded_value}",
+    );
+}
+
+// =============================================================================
+// Pod
+// =============================================================================
+
+#[test]
+fn roundtrip_pod_minimal() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {"name": "minimal", "namespace": "default"},
+        "spec": {
+            "containers": [{"name": "c", "image": "nginx"}]
+        }
+    }"#;
+    assert_roundtrip::<Pod>(fixture);
+}
+
+#[test]
+fn roundtrip_pod_with_node_name_and_status() {
+    // Status uses camelCase IP abbreviations: podIP / hostIP / containerID.
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {"name": "scheduled", "namespace": "default", "uid": "abc-123"},
+        "spec": {
+            "nodeName": "node-1",
+            "containers": [{"name": "c", "image": "nginx:1.25"}]
+        },
+        "status": {
+            "phase": "Running",
+            "podIP": "10.244.0.5",
+            "podIPs": [{"ip": "10.244.0.5"}],
+            "hostIP": "192.168.1.10",
+            "hostIPs": [{"ip": "192.168.1.10"}]
+        }
+    }"#;
+    assert_roundtrip::<Pod>(fixture);
+}
+
+#[test]
+fn roundtrip_pod_full_spec() {
+    // Exercises probes, env, volumeMounts, resources, restart policy,
+    // tolerations, affinity, securityContext.
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": "full",
+            "namespace": "default",
+            "labels": {"app": "web", "tier": "frontend"},
+            "annotations": {"note": "primary"}
+        },
+        "spec": {
+            "restartPolicy": "Always",
+            "terminationGracePeriodSeconds": 30,
+            "dnsPolicy": "ClusterFirst",
+            "serviceAccountName": "default",
+            "automountServiceAccountToken": true,
+            "nodeSelector": {"disktype": "ssd"},
+            "tolerations": [
+                {"key": "node-role", "operator": "Exists", "effect": "NoSchedule"}
+            ],
+            "containers": [{
+                "name": "app",
+                "image": "myapp:v1",
+                "command": ["/usr/bin/app"],
+                "args": ["--port", "8080"],
+                "ports": [{"containerPort": 8080, "protocol": "TCP", "name": "http"}],
+                "env": [
+                    {"name": "LOG_LEVEL", "value": "info"},
+                    {"name": "POD_NAME", "valueFrom": {"fieldRef": {"fieldPath": "metadata.name"}}}
+                ],
+                "resources": {
+                    "requests": {"cpu": "100m", "memory": "128Mi"},
+                    "limits":   {"cpu": "500m", "memory": "512Mi"}
+                },
+                "livenessProbe": {
+                    "httpGet": {"path": "/healthz", "port": 8080},
+                    "initialDelaySeconds": 10,
+                    "periodSeconds": 5
+                },
+                "readinessProbe": {
+                    "tcpSocket": {"port": 8080},
+                    "initialDelaySeconds": 5
+                },
+                "volumeMounts": [
+                    {"name": "data", "mountPath": "/var/data", "readOnly": false}
+                ],
+                "securityContext": {
+                    "runAsUser": 1000,
+                    "runAsNonRoot": true,
+                    "allowPrivilegeEscalation": false
+                }
+            }],
+            "volumes": [{
+                "name": "data",
+                "emptyDir": {}
+            }]
+        }
+    }"#;
+    assert_roundtrip::<Pod>(fixture);
+}
+
+#[test]
+fn roundtrip_pod_init_and_ephemeral_containers() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {"name": "init", "namespace": "default"},
+        "spec": {
+            "initContainers": [
+                {"name": "setup", "image": "busybox", "command": ["sh", "-c", "echo init"]}
+            ],
+            "containers": [{"name": "main", "image": "nginx"}],
+            "ephemeralContainers": [
+                {"name": "debugger", "image": "busybox", "command": ["sh"]}
+            ]
+        }
+    }"#;
+    assert_roundtrip::<Pod>(fixture);
+}
+
+#[test]
+fn roundtrip_pod_with_affinity_and_topology_spread() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {"name": "affine", "namespace": "default"},
+        "spec": {
+            "containers": [{"name": "c", "image": "nginx"}],
+            "affinity": {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [{
+                            "matchExpressions": [
+                                {"key": "kubernetes.io/os", "operator": "In", "values": ["linux"]}
+                            ]
+                        }]
+                    }
+                }
+            },
+            "topologySpreadConstraints": [{
+                "maxSkew": 1,
+                "topologyKey": "topology.kubernetes.io/zone",
+                "whenUnsatisfiable": "DoNotSchedule",
+                "labelSelector": {"matchLabels": {"app": "web"}}
+            }]
+        }
+    }"#;
+    assert_roundtrip::<Pod>(fixture);
+}
+
+#[test]
+fn roundtrip_pod_with_container_status() {
+    // Conformance tests round-trip ContainerStatus with containerID + image IDs.
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {"name": "with-status", "namespace": "default"},
+        "spec": {"containers": [{"name": "c", "image": "nginx"}]},
+        "status": {
+            "phase": "Running",
+            "conditions": [
+                {"type": "Ready", "status": "True"},
+                {"type": "ContainersReady", "status": "True"}
+            ],
+            "containerStatuses": [{
+                "name": "c",
+                "image": "nginx",
+                "imageID": "docker-pullable://nginx@sha256:abc",
+                "containerID": "containerd://1234",
+                "ready": true,
+                "restartCount": 0,
+                "started": true
+            }]
+        }
+    }"#;
+    assert_roundtrip::<Pod>(fixture);
+}
+
+// =============================================================================
+// ConfigMap
+// =============================================================================
+
+#[test]
+fn roundtrip_configmap_minimal() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {"name": "minimal", "namespace": "default"}
+    }"#;
+    assert_roundtrip::<ConfigMap>(fixture);
+}
+
+#[test]
+fn roundtrip_configmap_with_data() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {"name": "app-config", "namespace": "default"},
+        "data": {
+            "log.level": "info",
+            "feature.beta": "enabled"
+        }
+    }"#;
+    assert_roundtrip::<ConfigMap>(fixture);
+}
+
+#[test]
+fn roundtrip_configmap_with_binary_data() {
+    // binaryData values are base64-encoded on the wire.
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {"name": "bin", "namespace": "default"},
+        "data": {"text": "hello"},
+        "binaryData": {"blob": "aGVsbG8="}
+    }"#;
+    assert_roundtrip::<ConfigMap>(fixture);
+}
+
+#[test]
+fn roundtrip_configmap_immutable() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {"name": "frozen", "namespace": "default"},
+        "data": {"k": "v"},
+        "immutable": true
+    }"#;
+    assert_roundtrip::<ConfigMap>(fixture);
+}
+
+#[test]
+fn roundtrip_configmap_with_owner_reference() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {
+            "name": "owned",
+            "namespace": "default",
+            "ownerReferences": [{
+                "apiVersion": "apps/v1",
+                "kind": "Deployment",
+                "name": "web",
+                "uid": "11111111-2222-3333-4444-555555555555",
+                "controller": true,
+                "blockOwnerDeletion": true
+            }]
+        },
+        "data": {"k": "v"}
+    }"#;
+    assert_roundtrip::<ConfigMap>(fixture);
+}
+
+// =============================================================================
+// Secret
+// =============================================================================
+
+#[test]
+fn roundtrip_secret_minimal() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {"name": "minimal", "namespace": "default"},
+        "type": "Opaque"
+    }"#;
+    assert_roundtrip::<Secret>(fixture);
+}
+
+#[test]
+fn roundtrip_secret_opaque_with_data() {
+    // Secret.data values are base64-encoded on the wire.
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {"name": "creds", "namespace": "default"},
+        "type": "Opaque",
+        "data": {
+            "username": "YWRtaW4=",
+            "password": "cGFzc3dvcmQ="
+        }
+    }"#;
+    assert_roundtrip::<Secret>(fixture);
+}
+
+#[test]
+fn roundtrip_secret_with_string_data() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {"name": "tls", "namespace": "default"},
+        "type": "kubernetes.io/tls",
+        "stringData": {
+            "tls.crt": "-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----",
+            "tls.key": "-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----"
+        }
+    }"#;
+    assert_roundtrip::<Secret>(fixture);
+}
+
+#[test]
+fn roundtrip_secret_service_account_token() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {
+            "name": "default-token-abcde",
+            "namespace": "default",
+            "annotations": {
+                "kubernetes.io/service-account.name": "default",
+                "kubernetes.io/service-account.uid": "uuid-12345"
+            }
+        },
+        "type": "kubernetes.io/service-account-token",
+        "data": {
+            "ca.crt": "Y2EuY3J0",
+            "namespace": "ZGVmYXVsdA==",
+            "token": "dG9rZW4="
+        }
+    }"#;
+    assert_roundtrip::<Secret>(fixture);
+}
+
+#[test]
+fn roundtrip_secret_immutable() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {"name": "frozen", "namespace": "default"},
+        "type": "Opaque",
+        "immutable": true,
+        "data": {"k": "dg=="}
+    }"#;
+    assert_roundtrip::<Secret>(fixture);
+}
+
+// =============================================================================
+// Service
+// =============================================================================
+
+#[test]
+fn roundtrip_service_clusterip_minimal() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {"name": "minimal", "namespace": "default"},
+        "spec": {
+            "selector": {"app": "web"},
+            "ports": [{"port": 80, "targetPort": 8080, "protocol": "TCP"}]
+        }
+    }"#;
+    assert_roundtrip::<Service>(fixture);
+}
+
+#[test]
+fn roundtrip_service_clusterip_assigned() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {"name": "assigned", "namespace": "default"},
+        "spec": {
+            "type": "ClusterIP",
+            "selector": {"app": "web"},
+            "clusterIP": "10.96.0.10",
+            "clusterIPs": ["10.96.0.10"],
+            "ipFamilies": ["IPv4"],
+            "ipFamilyPolicy": "SingleStack",
+            "ports": [
+                {"name": "http", "port": 80, "targetPort": 8080, "protocol": "TCP"},
+                {"name": "https", "port": 443, "targetPort": "https", "protocol": "TCP"}
+            ]
+        }
+    }"#;
+    assert_roundtrip::<Service>(fixture);
+}
+
+#[test]
+fn roundtrip_service_nodeport() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {"name": "np", "namespace": "default"},
+        "spec": {
+            "type": "NodePort",
+            "selector": {"app": "web"},
+            "externalTrafficPolicy": "Local",
+            "ports": [{
+                "name": "http",
+                "port": 80,
+                "targetPort": 8080,
+                "nodePort": 31000,
+                "protocol": "TCP",
+                "appProtocol": "http"
+            }]
+        }
+    }"#;
+    assert_roundtrip::<Service>(fixture);
+}
+
+#[test]
+fn roundtrip_service_loadbalancer_with_status() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {"name": "lb", "namespace": "default"},
+        "spec": {
+            "type": "LoadBalancer",
+            "selector": {"app": "web"},
+            "ports": [{"port": 80, "targetPort": 8080, "protocol": "TCP"}],
+            "externalTrafficPolicy": "Cluster",
+            "allocateLoadBalancerNodePorts": true,
+            "loadBalancerSourceRanges": ["10.0.0.0/8", "192.168.0.0/16"]
+        },
+        "status": {
+            "loadBalancer": {
+                "ingress": [
+                    {"ip": "203.0.113.10", "ports": [{"port": 80, "protocol": "TCP"}]},
+                    {"hostname": "lb.example.com"}
+                ]
+            }
+        }
+    }"#;
+    assert_roundtrip::<Service>(fixture);
+}
+
+#[test]
+fn roundtrip_service_externalname() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {"name": "extn", "namespace": "default"},
+        "spec": {
+            "type": "ExternalName",
+            "externalName": "db.prod.svc.example.com"
+        }
+    }"#;
+    assert_roundtrip::<Service>(fixture);
+}
+
+#[test]
+fn roundtrip_service_headless_with_session_affinity() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {"name": "headless", "namespace": "default"},
+        "spec": {
+            "type": "ClusterIP",
+            "clusterIP": "None",
+            "selector": {"app": "db"},
+            "ports": [{"port": 5432, "targetPort": 5432, "protocol": "TCP"}],
+            "sessionAffinity": "ClientIP",
+            "sessionAffinityConfig": {
+                "clientIP": {"timeoutSeconds": 10800}
+            },
+            "publishNotReadyAddresses": true
+        }
+    }"#;
+    assert_roundtrip::<Service>(fixture);
+}
+
+// =============================================================================
+// Namespace
+// =============================================================================
+
+#[test]
+fn roundtrip_namespace_minimal() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Namespace",
+        "metadata": {"name": "default"}
+    }"#;
+    assert_roundtrip::<Namespace>(fixture);
+}
+
+#[test]
+fn roundtrip_namespace_active() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Namespace",
+        "metadata": {
+            "name": "kube-system",
+            "labels": {"kubernetes.io/metadata.name": "kube-system"}
+        },
+        "spec": {"finalizers": ["kubernetes"]},
+        "status": {"phase": "Active"}
+    }"#;
+    assert_roundtrip::<Namespace>(fixture);
+}
+
+#[test]
+fn roundtrip_namespace_terminating() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Namespace",
+        "metadata": {
+            "name": "stale",
+            "deletionTimestamp": "2026-01-01T00:00:00Z"
+        },
+        "spec": {"finalizers": ["kubernetes"]},
+        "status": {
+            "phase": "Terminating",
+            "conditions": [{
+                "type": "NamespaceDeletionDiscoveryFailure",
+                "status": "True",
+                "reason": "DiscoveryFailed",
+                "message": "Discovery failed for some groups"
+            }]
+        }
+    }"#;
+    assert_roundtrip::<Namespace>(fixture);
+}
+
+#[test]
+fn roundtrip_namespace_with_annotations() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Namespace",
+        "metadata": {
+            "name": "tenant-a",
+            "labels": {"team": "platform"},
+            "annotations": {"cost-center": "1234"}
+        },
+        "status": {"phase": "Active"}
+    }"#;
+    assert_roundtrip::<Namespace>(fixture);
+}
+
+// =============================================================================
+// Node
+// =============================================================================
+
+#[test]
+fn roundtrip_node_minimal() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Node",
+        "metadata": {"name": "node-1"},
+        "spec": null
+    }"#;
+    assert_roundtrip::<Node>(fixture);
+}
+
+#[test]
+fn roundtrip_node_with_taints_and_cidr() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Node",
+        "metadata": {"name": "node-1", "labels": {"kubernetes.io/hostname": "node-1"}},
+        "spec": {
+            "podCIDR": "10.244.0.0/24",
+            "podCIDRs": ["10.244.0.0/24"],
+            "providerID": "rusternetes://node-1",
+            "unschedulable": false,
+            "taints": [
+                {"key": "node-role.kubernetes.io/control-plane", "effect": "NoSchedule", "value": null}
+            ]
+        }
+    }"#;
+    assert_roundtrip::<Node>(fixture);
+}
+
+#[test]
+fn roundtrip_node_full_status() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Node",
+        "metadata": {"name": "node-1"},
+        "spec": {"podCIDR": "10.244.0.0/24"},
+        "status": {
+            "capacity": {"cpu": "4", "memory": "8Gi", "pods": "110"},
+            "allocatable": {"cpu": "3800m", "memory": "7Gi", "pods": "110"},
+            "addresses": [
+                {"type": "InternalIP", "address": "192.168.1.10"},
+                {"type": "Hostname", "address": "node-1"}
+            ],
+            "conditions": [
+                {"type": "Ready", "status": "True", "reason": "KubeletReady", "message": "kubelet is healthy"},
+                {"type": "MemoryPressure", "status": "False"},
+                {"type": "DiskPressure", "status": "False"}
+            ],
+            "nodeInfo": {
+                "machineID": "abc",
+                "systemUUID": "def",
+                "bootID": "ghi",
+                "kernelVersion": "6.1.0",
+                "osImage": "Ubuntu 22.04",
+                "containerRuntimeVersion": "containerd://1.7",
+                "kubeletVersion": "v1.35.0",
+                "kubeProxyVersion": "v1.35.0",
+                "operatingSystem": "linux",
+                "architecture": "amd64"
+            },
+            "daemonEndpoints": {"kubeletEndpoint": {"Port": 10250}}
+        }
+    }"#;
+    assert_roundtrip::<Node>(fixture);
+}
+
+#[test]
+fn roundtrip_node_with_images() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Node",
+        "metadata": {"name": "node-img"},
+        "spec": {},
+        "status": {
+            "images": [
+                {"names": ["nginx:latest", "nginx@sha256:abc"], "sizeBytes": 12345678},
+                {"names": ["busybox:1.36"], "sizeBytes": 1024000}
+            ]
+        }
+    }"#;
+    assert_roundtrip::<Node>(fixture);
+}
+
+#[test]
+fn roundtrip_node_with_runtime_handlers() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Node",
+        "metadata": {"name": "node-rh"},
+        "spec": {},
+        "status": {
+            "runtimeHandlers": [
+                {"name": "runc", "features": {"recursiveReadOnlyMounts": true, "userNamespaces": false}},
+                {"name": "kata"}
+            ],
+            "features": {"supplementalGroupsPolicy": true}
+        }
+    }"#;
+    assert_roundtrip::<Node>(fixture);
+}
+
+// =============================================================================
+// Event
+// =============================================================================
+
+#[test]
+fn roundtrip_event_core_v1_minimal() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Event",
+        "metadata": {"name": "evt.0001", "namespace": "default"},
+        "involvedObject": {
+            "kind": "Pod",
+            "namespace": "default",
+            "name": "web-0",
+            "uid": "11111111-2222-3333-4444-555555555555"
+        },
+        "reason": "Scheduled",
+        "message": "Successfully assigned default/web-0 to node-1",
+        "type": "Normal",
+        "source": {"component": "default-scheduler"},
+        "count": 1,
+        "firstTimestamp": "2026-01-01T00:00:00Z",
+        "lastTimestamp": "2026-01-01T00:00:00Z"
+    }"#;
+    assert_roundtrip::<Event>(fixture);
+}
+
+#[test]
+fn roundtrip_event_warning_with_series() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Event",
+        "metadata": {"name": "evt.warn", "namespace": "default"},
+        "involvedObject": {"kind": "Pod", "namespace": "default", "name": "broken", "uid": "u"},
+        "reason": "BackOff",
+        "message": "Back-off restarting failed container",
+        "type": "Warning",
+        "source": {"component": "kubelet", "host": "node-1"},
+        "count": 5,
+        "firstTimestamp": "2026-01-01T00:00:00Z",
+        "lastTimestamp": "2026-01-01T00:05:00Z",
+        "series": {"count": 5, "lastObservedTime": "2026-01-01T00:05:00.000000Z"}
+    }"#;
+    assert_roundtrip::<Event>(fixture);
+}
+
+#[test]
+fn roundtrip_event_events_k8s_io_v1_format() {
+    // events.k8s.io/v1 introduced reportingController/reportingInstance/regarding/note/eventTime.
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Event",
+        "metadata": {"name": "evt.new", "namespace": "default"},
+        "involvedObject": {"kind": "Pod", "namespace": "default", "name": "web-0", "uid": "u"},
+        "regarding": {"kind": "Pod", "namespace": "default", "name": "web-0", "uid": "u"},
+        "related": {"kind": "Node", "name": "node-1", "uid": "n"},
+        "reason": "Started",
+        "note": "Started container nginx",
+        "message": "Started container nginx",
+        "type": "Normal",
+        "action": "Binding",
+        "eventTime": "2026-01-01T00:00:00.123456Z",
+        "reportingComponent": "kubelet",
+        "reportingInstance": "kubelet-node-1",
+        "source": {"component": "kubelet", "host": "node-1"},
+        "count": 1
+    }"#;
+    assert_roundtrip::<Event>(fixture);
+}
+
+#[test]
+fn roundtrip_event_zero_count() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Event",
+        "metadata": {"name": "evt.zero", "namespace": "default"},
+        "involvedObject": {"kind": "Pod", "name": "p", "uid": "u"},
+        "reason": "",
+        "message": "",
+        "type": "Normal",
+        "source": {"component": ""},
+        "count": 0
+    }"#;
+    assert_roundtrip::<Event>(fixture);
+}
+
+// =============================================================================
+// ServiceAccount
+// =============================================================================
+
+#[test]
+fn roundtrip_service_account_minimal() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "ServiceAccount",
+        "metadata": {"name": "default", "namespace": "default"}
+    }"#;
+    assert_roundtrip::<ServiceAccount>(fixture);
+}
+
+#[test]
+fn roundtrip_service_account_with_secrets() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "ServiceAccount",
+        "metadata": {"name": "builder", "namespace": "ci"},
+        "secrets": [
+            {"kind": "Secret", "namespace": "ci", "name": "builder-token-abc"}
+        ],
+        "imagePullSecrets": [{"name": "regcred"}],
+        "automountServiceAccountToken": false
+    }"#;
+    assert_roundtrip::<ServiceAccount>(fixture);
+}
+
+#[test]
+fn roundtrip_service_account_with_owner_refs() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "ServiceAccount",
+        "metadata": {
+            "name": "owned-sa",
+            "namespace": "default",
+            "uid": "abc",
+            "ownerReferences": [{
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "name": "p",
+                "uid": "p-uid",
+                "controller": false,
+                "blockOwnerDeletion": false
+            }]
+        }
+    }"#;
+    assert_roundtrip::<ServiceAccount>(fixture);
+}
+
+// =============================================================================
+// PersistentVolume
+// =============================================================================
+
+#[test]
+fn roundtrip_persistent_volume_hostpath() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "PersistentVolume",
+        "metadata": {"name": "pv-host"},
+        "spec": {
+            "capacity": {"storage": "1Gi"},
+            "accessModes": ["ReadWriteOnce"],
+            "persistentVolumeReclaimPolicy": "Retain",
+            "storageClassName": "manual",
+            "hostPath": {"path": "/mnt/data", "type": "DirectoryOrCreate"}
+        }
+    }"#;
+    assert_roundtrip::<PersistentVolume>(fixture);
+}
+
+#[test]
+fn roundtrip_persistent_volume_nfs() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "PersistentVolume",
+        "metadata": {"name": "pv-nfs"},
+        "spec": {
+            "capacity": {"storage": "100Gi"},
+            "accessModes": ["ReadWriteMany"],
+            "persistentVolumeReclaimPolicy": "Recycle",
+            "nfs": {"server": "nfs.example.com", "path": "/exports/data", "readOnly": false},
+            "mountOptions": ["nfsvers=4.1"],
+            "volumeMode": "Filesystem"
+        }
+    }"#;
+    assert_roundtrip::<PersistentVolume>(fixture);
+}
+
+#[test]
+fn roundtrip_persistent_volume_csi() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "PersistentVolume",
+        "metadata": {"name": "pv-csi"},
+        "spec": {
+            "capacity": {"storage": "10Gi"},
+            "accessModes": ["ReadWriteOnce"],
+            "persistentVolumeReclaimPolicy": "Delete",
+            "storageClassName": "fast",
+            "csi": {
+                "driver": "ebs.csi.aws.com",
+                "volumeHandle": "vol-abc123",
+                "fsType": "ext4",
+                "readOnly": false,
+                "volumeAttributes": {"type": "gp3"}
+            },
+            "volumeMode": "Filesystem"
+        },
+        "status": {"phase": "Available"}
+    }"#;
+    assert_roundtrip::<PersistentVolume>(fixture);
+}
+
+#[test]
+fn roundtrip_persistent_volume_bound_with_claim_ref() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "PersistentVolume",
+        "metadata": {"name": "pv-bound"},
+        "spec": {
+            "capacity": {"storage": "5Gi"},
+            "accessModes": ["ReadWriteOnce"],
+            "persistentVolumeReclaimPolicy": "Retain",
+            "storageClassName": "standard",
+            "hostPath": {"path": "/mnt/pv-bound"},
+            "claimRef": {
+                "kind": "PersistentVolumeClaim",
+                "namespace": "default",
+                "name": "my-pvc",
+                "uid": "abc",
+                "apiVersion": "v1",
+                "resourceVersion": "42"
+            }
+        },
+        "status": {"phase": "Bound"}
+    }"#;
+    assert_roundtrip::<PersistentVolume>(fixture);
+}
+
+#[test]
+fn roundtrip_persistent_volume_with_node_affinity() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "PersistentVolume",
+        "metadata": {"name": "pv-local"},
+        "spec": {
+            "capacity": {"storage": "1Gi"},
+            "accessModes": ["ReadWriteOnce"],
+            "persistentVolumeReclaimPolicy": "Delete",
+            "storageClassName": "local-storage",
+            "local": {"path": "/mnt/disks/ssd1", "fsType": "ext4"},
+            "nodeAffinity": {
+                "required": {
+                    "nodeSelectorTerms": [{
+                        "matchExpressions": [
+                            {"key": "kubernetes.io/hostname", "operator": "In", "values": ["node-1"]}
+                        ]
+                    }]
+                }
+            }
+        }
+    }"#;
+    assert_roundtrip::<PersistentVolume>(fixture);
+}
+
+// =============================================================================
+// PersistentVolumeClaim
+// =============================================================================
+
+#[test]
+fn roundtrip_persistent_volume_claim_minimal() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "PersistentVolumeClaim",
+        "metadata": {"name": "pvc-min", "namespace": "default"},
+        "spec": {
+            "accessModes": ["ReadWriteOnce"],
+            "resources": {"requests": {"storage": "1Gi"}}
+        }
+    }"#;
+    assert_roundtrip::<PersistentVolumeClaim>(fixture);
+}
+
+#[test]
+fn roundtrip_persistent_volume_claim_with_storage_class() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "PersistentVolumeClaim",
+        "metadata": {"name": "pvc-sc", "namespace": "default"},
+        "spec": {
+            "accessModes": ["ReadWriteOnce"],
+            "resources": {"requests": {"storage": "10Gi"}, "limits": {"storage": "10Gi"}},
+            "storageClassName": "fast",
+            "volumeMode": "Filesystem"
+        }
+    }"#;
+    assert_roundtrip::<PersistentVolumeClaim>(fixture);
+}
+
+#[test]
+fn roundtrip_persistent_volume_claim_with_selector() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "PersistentVolumeClaim",
+        "metadata": {"name": "pvc-sel", "namespace": "default"},
+        "spec": {
+            "accessModes": ["ReadWriteOnce"],
+            "resources": {"requests": {"storage": "1Gi"}},
+            "selector": {
+                "matchLabels": {"tier": "gold"},
+                "matchExpressions": [
+                    {"key": "env", "operator": "In", "values": ["prod", "staging"]}
+                ]
+            }
+        }
+    }"#;
+    assert_roundtrip::<PersistentVolumeClaim>(fixture);
+}
+
+#[test]
+fn roundtrip_persistent_volume_claim_bound_status() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "PersistentVolumeClaim",
+        "metadata": {"name": "pvc-bound", "namespace": "default"},
+        "spec": {
+            "accessModes": ["ReadWriteOnce"],
+            "resources": {"requests": {"storage": "1Gi"}},
+            "volumeName": "pv-bound",
+            "storageClassName": "standard"
+        },
+        "status": {
+            "phase": "Bound",
+            "accessModes": ["ReadWriteOnce"],
+            "capacity": {"storage": "1Gi"}
+        }
+    }"#;
+    assert_roundtrip::<PersistentVolumeClaim>(fixture);
+}
+
+#[test]
+fn roundtrip_persistent_volume_claim_with_data_source() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "PersistentVolumeClaim",
+        "metadata": {"name": "pvc-clone", "namespace": "default"},
+        "spec": {
+            "accessModes": ["ReadWriteOnce"],
+            "resources": {"requests": {"storage": "5Gi"}},
+            "storageClassName": "fast",
+            "dataSource": {
+                "apiGroup": "snapshot.storage.k8s.io",
+                "kind": "VolumeSnapshot",
+                "name": "snap-1"
+            },
+            "dataSourceRef": {
+                "apiGroup": "snapshot.storage.k8s.io",
+                "kind": "VolumeSnapshot",
+                "name": "snap-1"
+            }
+        }
+    }"#;
+    assert_roundtrip::<PersistentVolumeClaim>(fixture);
+}
+
+// =============================================================================
+// Endpoints
+// =============================================================================
+
+#[test]
+fn roundtrip_endpoints_empty() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Endpoints",
+        "metadata": {"name": "empty", "namespace": "default"},
+        "subsets": []
+    }"#;
+    assert_roundtrip::<Endpoints>(fixture);
+}
+
+#[test]
+fn roundtrip_endpoints_single_subset() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Endpoints",
+        "metadata": {"name": "web", "namespace": "default"},
+        "subsets": [{
+            "addresses": [
+                {"ip": "10.244.0.5", "nodeName": "node-1"},
+                {"ip": "10.244.0.6", "nodeName": "node-2"}
+            ],
+            "ports": [
+                {"name": "http", "port": 8080, "protocol": "TCP"}
+            ]
+        }]
+    }"#;
+    assert_roundtrip::<Endpoints>(fixture);
+}
+
+#[test]
+fn roundtrip_endpoints_with_not_ready_addresses() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Endpoints",
+        "metadata": {"name": "mixed", "namespace": "default"},
+        "subsets": [{
+            "addresses": [{"ip": "10.244.0.5", "nodeName": "node-1"}],
+            "notReadyAddresses": [{"ip": "10.244.0.6", "nodeName": "node-2", "hostname": "pod-1"}],
+            "ports": [{"name": "http", "port": 80, "protocol": "TCP", "appProtocol": "http"}]
+        }]
+    }"#;
+    assert_roundtrip::<Endpoints>(fixture);
+}
+
+#[test]
+fn roundtrip_endpoints_with_target_ref() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Endpoints",
+        "metadata": {"name": "ref", "namespace": "default"},
+        "subsets": [{
+            "addresses": [{
+                "ip": "10.244.0.5",
+                "nodeName": "node-1",
+                "targetRef": {"kind": "Pod", "namespace": "default", "name": "web-0", "uid": "p-uid"}
+            }],
+            "ports": [{"port": 8080, "protocol": "TCP"}]
+        }]
+    }"#;
+    assert_roundtrip::<Endpoints>(fixture);
+}
+
+#[test]
+fn roundtrip_endpoints_multiple_subsets() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "Endpoints",
+        "metadata": {"name": "multi", "namespace": "default"},
+        "subsets": [
+            {
+                "addresses": [{"ip": "10.0.0.1"}, {"ip": "10.0.0.2"}],
+                "ports": [{"name": "http", "port": 80, "protocol": "TCP"}]
+            },
+            {
+                "addresses": [{"ip": "10.0.0.3"}],
+                "ports": [{"name": "metrics", "port": 9090, "protocol": "TCP"}]
+            }
+        ]
+    }"#;
+    assert_roundtrip::<Endpoints>(fixture);
+}
+
+// =============================================================================
+// LimitRange
+// =============================================================================
+
+#[test]
+fn roundtrip_limit_range_container() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "LimitRange",
+        "metadata": {"name": "container-defaults", "namespace": "default"},
+        "spec": {
+            "limits": [{
+                "type": "Container",
+                "max": {"cpu": "2", "memory": "1Gi"},
+                "min": {"cpu": "100m", "memory": "64Mi"},
+                "default": {"cpu": "500m", "memory": "256Mi"},
+                "defaultRequest": {"cpu": "200m", "memory": "128Mi"},
+                "maxLimitRequestRatio": {"cpu": "10"}
+            }]
+        }
+    }"#;
+    assert_roundtrip::<LimitRange>(fixture);
+}
+
+#[test]
+fn roundtrip_limit_range_pod() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "LimitRange",
+        "metadata": {"name": "pod-limits", "namespace": "default"},
+        "spec": {
+            "limits": [{
+                "type": "Pod",
+                "max": {"cpu": "4", "memory": "8Gi"}
+            }]
+        }
+    }"#;
+    assert_roundtrip::<LimitRange>(fixture);
+}
+
+#[test]
+fn roundtrip_limit_range_pvc() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "LimitRange",
+        "metadata": {"name": "pvc-limits", "namespace": "default"},
+        "spec": {
+            "limits": [{
+                "type": "PersistentVolumeClaim",
+                "max": {"storage": "100Gi"},
+                "min": {"storage": "1Gi"}
+            }]
+        }
+    }"#;
+    assert_roundtrip::<LimitRange>(fixture);
+}
+
+#[test]
+fn roundtrip_limit_range_multiple_items() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "LimitRange",
+        "metadata": {"name": "all", "namespace": "default"},
+        "spec": {
+            "limits": [
+                {"type": "Pod", "max": {"cpu": "4"}},
+                {"type": "Container", "default": {"memory": "256Mi"}, "defaultRequest": {"memory": "128Mi"}},
+                {"type": "PersistentVolumeClaim", "min": {"storage": "1Gi"}, "max": {"storage": "10Gi"}}
+            ]
+        }
+    }"#;
+    assert_roundtrip::<LimitRange>(fixture);
+}
+
+// =============================================================================
+// ResourceQuota
+// =============================================================================
+
+#[test]
+fn roundtrip_resource_quota_compute() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "ResourceQuota",
+        "metadata": {"name": "compute-quota", "namespace": "default"},
+        "spec": {
+            "hard": {
+                "pods": "10",
+                "requests.cpu": "4",
+                "requests.memory": "8Gi",
+                "limits.cpu": "10",
+                "limits.memory": "16Gi"
+            }
+        }
+    }"#;
+    assert_roundtrip::<ResourceQuota>(fixture);
+}
+
+#[test]
+fn roundtrip_resource_quota_object_counts() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "ResourceQuota",
+        "metadata": {"name": "obj-quota", "namespace": "default"},
+        "spec": {
+            "hard": {
+                "configmaps": "10",
+                "persistentvolumeclaims": "4",
+                "secrets": "10",
+                "services": "5",
+                "services.loadbalancers": "0"
+            }
+        }
+    }"#;
+    assert_roundtrip::<ResourceQuota>(fixture);
+}
+
+#[test]
+fn roundtrip_resource_quota_with_scopes() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "ResourceQuota",
+        "metadata": {"name": "best-effort", "namespace": "default"},
+        "spec": {
+            "hard": {"pods": "1000"},
+            "scopes": ["BestEffort"]
+        }
+    }"#;
+    assert_roundtrip::<ResourceQuota>(fixture);
+}
+
+#[test]
+fn roundtrip_resource_quota_with_scope_selector() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "ResourceQuota",
+        "metadata": {"name": "pc-quota", "namespace": "default"},
+        "spec": {
+            "hard": {"pods": "10"},
+            "scopeSelector": {
+                "matchExpressions": [{
+                    "scopeName": "PriorityClass",
+                    "operator": "In",
+                    "values": ["high", "critical"]
+                }]
+            }
+        }
+    }"#;
+    assert_roundtrip::<ResourceQuota>(fixture);
+}
+
+#[test]
+fn roundtrip_resource_quota_with_status() {
+    let fixture = r#"{
+        "apiVersion": "v1",
+        "kind": "ResourceQuota",
+        "metadata": {"name": "used", "namespace": "default"},
+        "spec": {"hard": {"pods": "10", "requests.cpu": "4"}},
+        "status": {
+            "hard": {"pods": "10", "requests.cpu": "4"},
+            "used": {"pods": "3", "requests.cpu": "1500m"}
+        }
+    }"#;
+    assert_roundtrip::<ResourceQuota>(fixture);
+}

--- a/crates/common/tests/roundtrip_networking.rs
+++ b/crates/common/tests/roundtrip_networking.rs
@@ -1,0 +1,1113 @@
+//! JSON roundtrip tests for `networking.k8s.io/v1` and `discovery.k8s.io/v1` resources.
+//!
+//! These tests mirror the upstream Kubernetes "roundtrip" layer (layer #1 in the
+//! kube-apiserver test stack). Each fixture is a hand-written JSON document that:
+//!
+//! 1. Deserialises into the strongly-typed Rust resource via `serde_json::from_str`,
+//! 2. Re-serialises back to a JSON string,
+//! 3. Re-deserialises from that string, and
+//! 4. Compares the two decoded values for equality.
+//!
+//! Equality is asserted at the typed level when the resource derives `PartialEq`.
+//! For resources that do not (`NetworkPolicy`, `EndpointSlice`), we compare
+//! `serde_json::Value` round-trips, which is equivalent for a stable serializer
+//! (it normalises field order / whitespace / map ordering).
+//!
+//! Resources covered:
+//! - `Ingress` (TLS, pathType Prefix/Exact/ImplementationSpecific, defaultBackend, multi-rule)
+//! - `IngressClass` (controller only, cluster/namespaced parameters)
+//! - `NetworkPolicy` (podSelector, ingress + egress, ipBlock, namespaceSelector, named ports)
+//! - `EndpointSlice` (IPv4/IPv6/FQDN, multi-port, topology hints)
+
+use rusternetes_common::resources::{EndpointSlice, Ingress, IngressClass, NetworkPolicy};
+
+// ---------- helpers ----------
+
+/// Roundtrip a fixture through a type that derives `PartialEq`.
+///
+/// Asserts that decode + re-encode + re-decode produces an equal value.
+fn assert_roundtrip_eq<T>(fixture: &str)
+where
+    T: serde::de::DeserializeOwned + serde::Serialize + PartialEq + std::fmt::Debug,
+{
+    let decoded: T =
+        serde_json::from_str(fixture).expect("fixture should decode into the target type");
+
+    let re_encoded =
+        serde_json::to_string(&decoded).expect("decoded value should re-encode to JSON");
+
+    let re_decoded: T = serde_json::from_str(&re_encoded)
+        .expect("re-encoded JSON should decode into the target type");
+
+    assert_eq!(
+        decoded, re_decoded,
+        "roundtrip should be stable: decoded != re_decoded"
+    );
+}
+
+/// Roundtrip a fixture through a type that does NOT derive `PartialEq`.
+///
+/// Falls back to `serde_json::Value` equality on the canonical re-encoded form.
+fn assert_roundtrip_value_eq<T>(fixture: &str)
+where
+    T: serde::de::DeserializeOwned + serde::Serialize,
+{
+    let decoded: T =
+        serde_json::from_str(fixture).expect("fixture should decode into the target type");
+
+    let first_encode =
+        serde_json::to_string(&decoded).expect("decoded value should re-encode to JSON");
+
+    let re_decoded: T = serde_json::from_str(&first_encode)
+        .expect("re-encoded JSON should decode into the target type");
+
+    let second_encode =
+        serde_json::to_string(&re_decoded).expect("re-decoded value should re-encode to JSON");
+
+    let first_value: serde_json::Value = serde_json::from_str(&first_encode).unwrap();
+    let second_value: serde_json::Value = serde_json::from_str(&second_encode).unwrap();
+
+    assert_eq!(
+        first_value, second_value,
+        "roundtrip should be stable: first encode != second encode"
+    );
+}
+
+// =====================================================================
+// Ingress (networking.k8s.io/v1)
+// =====================================================================
+
+#[test]
+fn roundtrip_ingress_minimal() {
+    let fixture = r#"{
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "Ingress",
+        "metadata": {
+            "name": "minimal",
+            "namespace": "default"
+        }
+    }"#;
+    assert_roundtrip_eq::<Ingress>(fixture);
+}
+
+#[test]
+fn roundtrip_ingress_default_backend_only() {
+    let fixture = r#"{
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "Ingress",
+        "metadata": {
+            "name": "default-backend",
+            "namespace": "default"
+        },
+        "spec": {
+            "ingressClassName": "nginx",
+            "defaultBackend": {
+                "service": {
+                    "name": "fallback",
+                    "port": {
+                        "number": 8080
+                    }
+                }
+            }
+        }
+    }"#;
+    assert_roundtrip_eq::<Ingress>(fixture);
+}
+
+#[test]
+fn roundtrip_ingress_path_type_prefix() {
+    let fixture = r#"{
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "Ingress",
+        "metadata": {
+            "name": "prefix-rules",
+            "namespace": "web"
+        },
+        "spec": {
+            "ingressClassName": "nginx",
+            "rules": [
+                {
+                    "host": "example.com",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/api",
+                                "pathType": "Prefix",
+                                "backend": {
+                                    "service": {
+                                        "name": "api",
+                                        "port": {
+                                            "number": 80
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }"#;
+    assert_roundtrip_eq::<Ingress>(fixture);
+}
+
+#[test]
+fn roundtrip_ingress_path_type_exact() {
+    let fixture = r#"{
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "Ingress",
+        "metadata": {
+            "name": "exact-rules",
+            "namespace": "web"
+        },
+        "spec": {
+            "rules": [
+                {
+                    "host": "exact.example.com",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/healthz",
+                                "pathType": "Exact",
+                                "backend": {
+                                    "service": {
+                                        "name": "health",
+                                        "port": {
+                                            "name": "http"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }"#;
+    assert_roundtrip_eq::<Ingress>(fixture);
+}
+
+#[test]
+fn roundtrip_ingress_path_type_implementation_specific() {
+    let fixture = r#"{
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "Ingress",
+        "metadata": {
+            "name": "impl-specific",
+            "namespace": "legacy"
+        },
+        "spec": {
+            "rules": [
+                {
+                    "host": "legacy.example.com",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/.*",
+                                "pathType": "ImplementationSpecific",
+                                "backend": {
+                                    "service": {
+                                        "name": "legacy",
+                                        "port": {
+                                            "number": 443
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }"#;
+    assert_roundtrip_eq::<Ingress>(fixture);
+}
+
+#[test]
+fn roundtrip_ingress_with_tls() {
+    let fixture = r#"{
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "Ingress",
+        "metadata": {
+            "name": "tls-ingress",
+            "namespace": "secure"
+        },
+        "spec": {
+            "ingressClassName": "nginx",
+            "tls": [
+                {
+                    "hosts": ["secure.example.com", "www.secure.example.com"],
+                    "secretName": "secure-tls"
+                },
+                {
+                    "hosts": ["api.secure.example.com"],
+                    "secretName": "api-tls"
+                }
+            ],
+            "rules": [
+                {
+                    "host": "secure.example.com",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/",
+                                "pathType": "Prefix",
+                                "backend": {
+                                    "service": {
+                                        "name": "web",
+                                        "port": {
+                                            "number": 443
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }"#;
+    assert_roundtrip_eq::<Ingress>(fixture);
+}
+
+#[test]
+fn roundtrip_ingress_multiple_rules_and_paths() {
+    let fixture = r#"{
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "Ingress",
+        "metadata": {
+            "name": "multi-rule",
+            "namespace": "platform",
+            "labels": {
+                "app.kubernetes.io/name": "platform-router"
+            }
+        },
+        "spec": {
+            "ingressClassName": "nginx",
+            "defaultBackend": {
+                "service": {
+                    "name": "default-svc",
+                    "port": {
+                        "number": 80
+                    }
+                }
+            },
+            "rules": [
+                {
+                    "host": "a.example.com",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/v1",
+                                "pathType": "Prefix",
+                                "backend": {
+                                    "service": {
+                                        "name": "svc-v1",
+                                        "port": {
+                                            "number": 80
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "path": "/v2",
+                                "pathType": "Prefix",
+                                "backend": {
+                                    "service": {
+                                        "name": "svc-v2",
+                                        "port": {
+                                            "number": 80
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "host": "b.example.com",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/foo",
+                                "pathType": "Exact",
+                                "backend": {
+                                    "service": {
+                                        "name": "svc-foo",
+                                        "port": {
+                                            "name": "http"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }"#;
+    assert_roundtrip_eq::<Ingress>(fixture);
+}
+
+#[test]
+fn roundtrip_ingress_with_status_loadbalancer() {
+    let fixture = r#"{
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "Ingress",
+        "metadata": {
+            "name": "status-ingress",
+            "namespace": "default"
+        },
+        "spec": {
+            "ingressClassName": "nginx",
+            "rules": [
+                {
+                    "host": "status.example.com",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/",
+                                "pathType": "Prefix",
+                                "backend": {
+                                    "service": {
+                                        "name": "svc",
+                                        "port": {
+                                            "number": 80
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "status": {
+            "loadBalancer": {
+                "ingress": [
+                    {
+                        "ip": "203.0.113.10",
+                        "hostname": "lb.example.com",
+                        "ports": [
+                            {
+                                "port": 80,
+                                "protocol": "TCP"
+                            },
+                            {
+                                "port": 443,
+                                "protocol": "TCP",
+                                "error": "cert-pending"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }"#;
+    assert_roundtrip_eq::<Ingress>(fixture);
+}
+
+// =====================================================================
+// IngressClass (networking.k8s.io/v1)
+// =====================================================================
+
+#[test]
+fn roundtrip_ingressclass_minimal() {
+    let fixture = r#"{
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "IngressClass",
+        "metadata": {
+            "name": "nginx"
+        }
+    }"#;
+    assert_roundtrip_eq::<IngressClass>(fixture);
+}
+
+#[test]
+fn roundtrip_ingressclass_controller_only() {
+    let fixture = r#"{
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "IngressClass",
+        "metadata": {
+            "name": "nginx",
+            "annotations": {
+                "ingressclass.kubernetes.io/is-default-class": "true"
+            }
+        },
+        "spec": {
+            "controller": "k8s.io/ingress-nginx"
+        }
+    }"#;
+    assert_roundtrip_eq::<IngressClass>(fixture);
+}
+
+#[test]
+fn roundtrip_ingressclass_cluster_scoped_parameters() {
+    let fixture = r#"{
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "IngressClass",
+        "metadata": {
+            "name": "acme"
+        },
+        "spec": {
+            "controller": "acme.io/ingress-controller",
+            "parameters": {
+                "apiGroup": "acme.io",
+                "kind": "IngressConfig",
+                "name": "global-config",
+                "scope": "Cluster"
+            }
+        }
+    }"#;
+    assert_roundtrip_eq::<IngressClass>(fixture);
+}
+
+#[test]
+fn roundtrip_ingressclass_namespace_scoped_parameters() {
+    let fixture = r#"{
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "IngressClass",
+        "metadata": {
+            "name": "external-lb"
+        },
+        "spec": {
+            "controller": "example.com/ingress-controller",
+            "parameters": {
+                "apiGroup": "k8s.example.com",
+                "kind": "IngressParameters",
+                "name": "external-lb",
+                "namespace": "ingress-system",
+                "scope": "Namespace"
+            }
+        }
+    }"#;
+    assert_roundtrip_eq::<IngressClass>(fixture);
+}
+
+#[test]
+fn roundtrip_ingressclass_core_api_group_parameters() {
+    // apiGroup omitted -> core API group (configmap reference)
+    let fixture = r#"{
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "IngressClass",
+        "metadata": {
+            "name": "core-params"
+        },
+        "spec": {
+            "controller": "example.com/ingress-controller",
+            "parameters": {
+                "kind": "ConfigMap",
+                "name": "ingress-config",
+                "namespace": "kube-system",
+                "scope": "Namespace"
+            }
+        }
+    }"#;
+    assert_roundtrip_eq::<IngressClass>(fixture);
+}
+
+// =====================================================================
+// NetworkPolicy (networking.k8s.io/v1)
+// =====================================================================
+//
+// `NetworkPolicy` does not derive `PartialEq`, so we use JSON-Value equality.
+
+#[test]
+fn roundtrip_networkpolicy_pod_selector_only() {
+    let fixture = r#"{
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "NetworkPolicy",
+        "metadata": {
+            "name": "default-deny",
+            "namespace": "default"
+        },
+        "spec": {
+            "podSelector": {},
+            "policyTypes": ["Ingress"]
+        }
+    }"#;
+    assert_roundtrip_value_eq::<NetworkPolicy>(fixture);
+}
+
+#[test]
+fn roundtrip_networkpolicy_ingress_from_pod_selector() {
+    let fixture = r#"{
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "NetworkPolicy",
+        "metadata": {
+            "name": "allow-from-app",
+            "namespace": "default"
+        },
+        "spec": {
+            "podSelector": {
+                "matchLabels": {
+                    "app": "db"
+                }
+            },
+            "policyTypes": ["Ingress"],
+            "ingress": [
+                {
+                    "from": [
+                        {
+                            "podSelector": {
+                                "matchLabels": {
+                                    "app": "web"
+                                }
+                            }
+                        }
+                    ],
+                    "ports": [
+                        {
+                            "protocol": "TCP",
+                            "port": 5432
+                        }
+                    ]
+                }
+            ]
+        }
+    }"#;
+    assert_roundtrip_value_eq::<NetworkPolicy>(fixture);
+}
+
+#[test]
+fn roundtrip_networkpolicy_ingress_namespace_selector() {
+    let fixture = r#"{
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "NetworkPolicy",
+        "metadata": {
+            "name": "allow-from-monitoring",
+            "namespace": "production"
+        },
+        "spec": {
+            "podSelector": {
+                "matchLabels": {
+                    "tier": "backend"
+                }
+            },
+            "policyTypes": ["Ingress"],
+            "ingress": [
+                {
+                    "from": [
+                        {
+                            "namespaceSelector": {
+                                "matchLabels": {
+                                    "purpose": "monitoring"
+                                }
+                            }
+                        }
+                    ],
+                    "ports": [
+                        {
+                            "protocol": "TCP",
+                            "port": "metrics"
+                        }
+                    ]
+                }
+            ]
+        }
+    }"#;
+    assert_roundtrip_value_eq::<NetworkPolicy>(fixture);
+}
+
+#[test]
+fn roundtrip_networkpolicy_ingress_ip_block() {
+    let fixture = r#"{
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "NetworkPolicy",
+        "metadata": {
+            "name": "allow-cidr",
+            "namespace": "default"
+        },
+        "spec": {
+            "podSelector": {
+                "matchLabels": {
+                    "app": "api"
+                }
+            },
+            "policyTypes": ["Ingress"],
+            "ingress": [
+                {
+                    "from": [
+                        {
+                            "ipBlock": {
+                                "cidr": "10.0.0.0/8",
+                                "except": [
+                                    "10.0.0.0/24",
+                                    "10.0.1.0/24"
+                                ]
+                            }
+                        }
+                    ],
+                    "ports": [
+                        {
+                            "protocol": "TCP",
+                            "port": 8080,
+                            "endPort": 8090
+                        }
+                    ]
+                }
+            ]
+        }
+    }"#;
+    assert_roundtrip_value_eq::<NetworkPolicy>(fixture);
+}
+
+#[test]
+fn roundtrip_networkpolicy_egress_only() {
+    let fixture = r#"{
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "NetworkPolicy",
+        "metadata": {
+            "name": "allow-egress-dns",
+            "namespace": "default"
+        },
+        "spec": {
+            "podSelector": {},
+            "policyTypes": ["Egress"],
+            "egress": [
+                {
+                    "to": [
+                        {
+                            "namespaceSelector": {
+                                "matchLabels": {
+                                    "kubernetes.io/metadata.name": "kube-system"
+                                }
+                            },
+                            "podSelector": {
+                                "matchLabels": {
+                                    "k8s-app": "kube-dns"
+                                }
+                            }
+                        }
+                    ],
+                    "ports": [
+                        {
+                            "protocol": "UDP",
+                            "port": 53
+                        },
+                        {
+                            "protocol": "TCP",
+                            "port": 53
+                        }
+                    ]
+                }
+            ]
+        }
+    }"#;
+    assert_roundtrip_value_eq::<NetworkPolicy>(fixture);
+}
+
+#[test]
+fn roundtrip_networkpolicy_ingress_and_egress() {
+    let fixture = r#"{
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "NetworkPolicy",
+        "metadata": {
+            "name": "full-policy",
+            "namespace": "production"
+        },
+        "spec": {
+            "podSelector": {
+                "matchExpressions": [
+                    {
+                        "key": "tier",
+                        "operator": "In",
+                        "values": ["backend", "frontend"]
+                    }
+                ]
+            },
+            "policyTypes": ["Ingress", "Egress"],
+            "ingress": [
+                {
+                    "from": [
+                        {
+                            "podSelector": {
+                                "matchLabels": {
+                                    "role": "client"
+                                }
+                            },
+                            "namespaceSelector": {
+                                "matchLabels": {
+                                    "env": "prod"
+                                }
+                            }
+                        },
+                        {
+                            "ipBlock": {
+                                "cidr": "172.16.0.0/12"
+                            }
+                        }
+                    ],
+                    "ports": [
+                        {
+                            "protocol": "TCP",
+                            "port": 8443
+                        }
+                    ]
+                }
+            ],
+            "egress": [
+                {
+                    "to": [
+                        {
+                            "ipBlock": {
+                                "cidr": "0.0.0.0/0",
+                                "except": ["10.0.0.0/8"]
+                            }
+                        }
+                    ],
+                    "ports": [
+                        {
+                            "protocol": "TCP",
+                            "port": 443
+                        }
+                    ]
+                }
+            ]
+        }
+    }"#;
+    assert_roundtrip_value_eq::<NetworkPolicy>(fixture);
+}
+
+#[test]
+fn roundtrip_networkpolicy_allow_all() {
+    // Empty `from` + empty `ports` means "allow all" upstream semantics.
+    let fixture = r#"{
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "NetworkPolicy",
+        "metadata": {
+            "name": "allow-all",
+            "namespace": "default"
+        },
+        "spec": {
+            "podSelector": {},
+            "policyTypes": ["Ingress", "Egress"],
+            "ingress": [{}],
+            "egress": [{}]
+        }
+    }"#;
+    assert_roundtrip_value_eq::<NetworkPolicy>(fixture);
+}
+
+// =====================================================================
+// EndpointSlice (discovery.k8s.io/v1)
+// =====================================================================
+//
+// `EndpointSlice` itself does not derive `PartialEq`, so we use JSON-Value
+// equality. The nested types (`Endpoint`, `EndpointPort`, …) do, but the
+// outermost roundtrip still needs the value-comparison helper.
+
+#[test]
+fn roundtrip_endpointslice_ipv4_minimal() {
+    let fixture = r#"{
+        "apiVersion": "discovery.k8s.io/v1",
+        "kind": "EndpointSlice",
+        "metadata": {
+            "name": "my-svc-abc",
+            "namespace": "default",
+            "labels": {
+                "kubernetes.io/service-name": "my-svc"
+            }
+        },
+        "addressType": "IPv4",
+        "endpoints": [
+            {
+                "addresses": ["10.1.2.3"],
+                "conditions": {
+                    "ready": true,
+                    "serving": true,
+                    "terminating": false
+                }
+            }
+        ],
+        "ports": [
+            {
+                "name": "http",
+                "port": 80,
+                "protocol": "TCP"
+            }
+        ]
+    }"#;
+    assert_roundtrip_value_eq::<EndpointSlice>(fixture);
+}
+
+#[test]
+fn roundtrip_endpointslice_ipv6() {
+    let fixture = r#"{
+        "apiVersion": "discovery.k8s.io/v1",
+        "kind": "EndpointSlice",
+        "metadata": {
+            "name": "my-svc-v6",
+            "namespace": "default"
+        },
+        "addressType": "IPv6",
+        "endpoints": [
+            {
+                "addresses": ["2001:db8::1", "2001:db8::2"],
+                "conditions": {
+                    "ready": true
+                },
+                "hostname": "pod-1",
+                "nodeName": "node-1",
+                "zone": "us-east-1a"
+            }
+        ],
+        "ports": [
+            {
+                "name": "https",
+                "port": 443,
+                "protocol": "TCP",
+                "appProtocol": "https"
+            }
+        ]
+    }"#;
+    assert_roundtrip_value_eq::<EndpointSlice>(fixture);
+}
+
+#[test]
+fn roundtrip_endpointslice_fqdn() {
+    let fixture = r#"{
+        "apiVersion": "discovery.k8s.io/v1",
+        "kind": "EndpointSlice",
+        "metadata": {
+            "name": "external-svc-fqdn",
+            "namespace": "default"
+        },
+        "addressType": "FQDN",
+        "endpoints": [
+            {
+                "addresses": ["external.example.com"],
+                "conditions": {
+                    "ready": true,
+                    "serving": true,
+                    "terminating": false
+                }
+            }
+        ],
+        "ports": [
+            {
+                "port": 443,
+                "protocol": "TCP"
+            }
+        ]
+    }"#;
+    assert_roundtrip_value_eq::<EndpointSlice>(fixture);
+}
+
+#[test]
+fn roundtrip_endpointslice_multiple_ports() {
+    let fixture = r#"{
+        "apiVersion": "discovery.k8s.io/v1",
+        "kind": "EndpointSlice",
+        "metadata": {
+            "name": "multi-port-svc",
+            "namespace": "platform",
+            "labels": {
+                "kubernetes.io/service-name": "multi-port-svc",
+                "endpointslice.kubernetes.io/managed-by": "endpointslice-controller.k8s.io"
+            }
+        },
+        "addressType": "IPv4",
+        "endpoints": [
+            {
+                "addresses": ["10.0.0.5"],
+                "conditions": {
+                    "ready": true,
+                    "serving": true,
+                    "terminating": false
+                },
+                "targetRef": {
+                    "kind": "Pod",
+                    "namespace": "platform",
+                    "name": "backend-7d8f-abc",
+                    "uid": "11111111-2222-3333-4444-555555555555"
+                },
+                "nodeName": "node-1",
+                "zone": "us-west-2a"
+            }
+        ],
+        "ports": [
+            {
+                "name": "http",
+                "port": 8080,
+                "protocol": "TCP",
+                "appProtocol": "http"
+            },
+            {
+                "name": "grpc",
+                "port": 9090,
+                "protocol": "TCP",
+                "appProtocol": "grpc"
+            },
+            {
+                "name": "metrics",
+                "port": 9100,
+                "protocol": "TCP"
+            }
+        ]
+    }"#;
+    assert_roundtrip_value_eq::<EndpointSlice>(fixture);
+}
+
+#[test]
+fn roundtrip_endpointslice_with_topology_hints() {
+    let fixture = r#"{
+        "apiVersion": "discovery.k8s.io/v1",
+        "kind": "EndpointSlice",
+        "metadata": {
+            "name": "topology-slice",
+            "namespace": "default"
+        },
+        "addressType": "IPv4",
+        "endpoints": [
+            {
+                "addresses": ["10.0.0.10"],
+                "conditions": {
+                    "ready": true
+                },
+                "zone": "us-east-1a",
+                "nodeName": "node-1",
+                "hints": {
+                    "forZones": [
+                        {"name": "us-east-1a"},
+                        {"name": "us-east-1b"}
+                    ]
+                }
+            },
+            {
+                "addresses": ["10.0.0.11"],
+                "conditions": {
+                    "ready": true
+                },
+                "zone": "us-east-1b",
+                "nodeName": "node-2",
+                "hints": {
+                    "forZones": [
+                        {"name": "us-east-1b"}
+                    ]
+                }
+            }
+        ],
+        "ports": [
+            {
+                "name": "http",
+                "port": 80,
+                "protocol": "TCP"
+            }
+        ]
+    }"#;
+    assert_roundtrip_value_eq::<EndpointSlice>(fixture);
+}
+
+#[test]
+fn roundtrip_endpointslice_not_ready_endpoint() {
+    let fixture = r#"{
+        "apiVersion": "discovery.k8s.io/v1",
+        "kind": "EndpointSlice",
+        "metadata": {
+            "name": "mixed-readiness",
+            "namespace": "default"
+        },
+        "addressType": "IPv4",
+        "endpoints": [
+            {
+                "addresses": ["10.0.0.20"],
+                "conditions": {
+                    "ready": true,
+                    "serving": true,
+                    "terminating": false
+                }
+            },
+            {
+                "addresses": ["10.0.0.21"],
+                "conditions": {
+                    "ready": false,
+                    "serving": true,
+                    "terminating": true
+                },
+                "targetRef": {
+                    "kind": "Pod",
+                    "namespace": "default",
+                    "name": "terminating-pod"
+                }
+            },
+            {
+                "addresses": ["10.0.0.22"],
+                "conditions": {
+                    "ready": false,
+                    "serving": false,
+                    "terminating": false
+                }
+            }
+        ],
+        "ports": [
+            {
+                "name": "http",
+                "port": 80,
+                "protocol": "TCP"
+            }
+        ]
+    }"#;
+    assert_roundtrip_value_eq::<EndpointSlice>(fixture);
+}
+
+#[test]
+fn roundtrip_endpointslice_multiple_addresses_per_endpoint() {
+    // Per upstream: addresses[] may contain multiple addresses of the same type
+    // (e.g. dual-IPv4 NICs for a single endpoint).
+    let fixture = r#"{
+        "apiVersion": "discovery.k8s.io/v1",
+        "kind": "EndpointSlice",
+        "metadata": {
+            "name": "dual-nic-slice",
+            "namespace": "default"
+        },
+        "addressType": "IPv4",
+        "endpoints": [
+            {
+                "addresses": ["10.0.0.30", "10.0.0.31"],
+                "conditions": {
+                    "ready": true,
+                    "serving": true,
+                    "terminating": false
+                },
+                "hostname": "dual-nic-host",
+                "nodeName": "node-3"
+            }
+        ],
+        "ports": [
+            {
+                "port": 80,
+                "protocol": "TCP"
+            }
+        ]
+    }"#;
+    assert_roundtrip_value_eq::<EndpointSlice>(fixture);
+}
+
+#[test]
+fn roundtrip_endpointslice_no_ports_headless() {
+    // Headless service variant: addressType set, endpoints present, no ports.
+    let fixture = r#"{
+        "apiVersion": "discovery.k8s.io/v1",
+        "kind": "EndpointSlice",
+        "metadata": {
+            "name": "headless-slice",
+            "namespace": "default",
+            "labels": {
+                "kubernetes.io/service-name": "headless"
+            }
+        },
+        "addressType": "IPv4",
+        "endpoints": [
+            {
+                "addresses": ["10.0.0.40"],
+                "conditions": {
+                    "ready": true
+                },
+                "hostname": "pod-0"
+            }
+        ]
+    }"#;
+    assert_roundtrip_value_eq::<EndpointSlice>(fixture);
+}

--- a/crates/common/tests/roundtrip_rbac_storage.rs
+++ b/crates/common/tests/roundtrip_rbac_storage.rs
@@ -1,0 +1,794 @@
+// JSON roundtrip tests for the long tail of group/version resources.
+//
+// These tests mirror upstream Kubernetes' "roundtrip" test layer: each
+// hand-written JSON fixture is deserialized into the strongly-typed Rust
+// representation, then re-serialized and deserialized a second time, with the
+// final value compared structurally to the first decode. Equality is checked
+// via `serde_json::Value` so that types that intentionally do not implement
+// `PartialEq` (e.g. `StorageClass`, `CSIDriver`, `PriorityClass`) are still
+// exercised. Any drift in `#[serde(rename_all = "camelCase")]`, alias handling,
+// enum variant casing, or `skip_serializing_if` logic surfaces here as a
+// failing assertion.
+//
+// Resources covered:
+//   - Role, RoleBinding, ClusterRole, ClusterRoleBinding (rbac.authorization.k8s.io/v1)
+//   - PriorityClass (scheduling.k8s.io/v1)
+//   - StorageClass, CSIDriver, VolumeAttachment (storage.k8s.io/v1)
+//   - RuntimeClass (node.k8s.io/v1)
+//   - FlowSchema, PriorityLevelConfiguration (flowcontrol.apiserver.k8s.io/v1)
+//   - ValidatingWebhookConfiguration, MutatingWebhookConfiguration (admissionregistration.k8s.io/v1)
+//   - CustomResourceDefinition (apiextensions.k8s.io/v1)
+
+use rusternetes_common::resources::{
+    CSIDriver, ClusterRole, ClusterRoleBinding, CustomResourceDefinition, FlowSchema,
+    MutatingWebhookConfiguration, PriorityClass, PriorityLevelConfiguration, Role, RoleBinding,
+    RuntimeClass, StorageClass, ValidatingWebhookConfiguration, VolumeAttachment,
+};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+/// Roundtrip a hand-written JSON fixture through `T`.
+///
+/// Asserts (per the upstream contract):
+///   1. `serde_json::from_str::<T>(fixture)` succeeds (`decoded`),
+///   2. `serde_json::to_string(&decoded)` succeeds (`re_encoded`),
+///   3. `serde_json::from_str::<T>(&re_encoded)` succeeds (`re_decoded`),
+///   4. `decoded == re_decoded` — compared as `serde_json::Value` so the check
+///      works uniformly for types whether or not they implement `PartialEq`.
+fn assert_roundtrip<T: Serialize + DeserializeOwned>(fixture: &str) {
+    let decoded: T = serde_json::from_str(fixture)
+        .unwrap_or_else(|e| panic!("step 1 decode failed: {e}\nfixture: {fixture}"));
+
+    let re_encoded =
+        serde_json::to_string(&decoded).unwrap_or_else(|e| panic!("step 2 encode failed: {e}"));
+
+    let re_decoded: T = serde_json::from_str(&re_encoded)
+        .unwrap_or_else(|e| panic!("step 3 re-decode failed: {e}\nre_encoded: {re_encoded}"));
+
+    let lhs = serde_json::to_value(&decoded).expect("decoded -> Value");
+    let rhs = serde_json::to_value(&re_decoded).expect("re_decoded -> Value");
+    assert_eq!(
+        lhs, rhs,
+        "step 4: decoded != re_decoded after JSON roundtrip"
+    );
+}
+
+// =============================================================================
+// rbac.authorization.k8s.io/v1
+// =============================================================================
+
+#[test]
+fn roundtrip_role_minimal() {
+    let fixture = r#"{
+        "apiVersion": "rbac.authorization.k8s.io/v1",
+        "kind": "Role",
+        "metadata": {"name": "pod-reader", "namespace": "default"},
+        "rules": []
+    }"#;
+    assert_roundtrip::<Role>(fixture);
+}
+
+#[test]
+fn roundtrip_role_with_rules() {
+    let fixture = r#"{
+        "apiVersion": "rbac.authorization.k8s.io/v1",
+        "kind": "Role",
+        "metadata": {"name": "pod-reader", "namespace": "kube-system"},
+        "rules": [
+            {
+                "verbs": ["get", "list", "watch"],
+                "apiGroups": [""],
+                "resources": ["pods", "pods/log"]
+            },
+            {
+                "verbs": ["get"],
+                "apiGroups": [""],
+                "resources": ["pods"],
+                "resourceNames": ["my-pod"]
+            }
+        ]
+    }"#;
+    assert_roundtrip::<Role>(fixture);
+}
+
+#[test]
+fn roundtrip_rolebinding_user_subject() {
+    let fixture = r#"{
+        "apiVersion": "rbac.authorization.k8s.io/v1",
+        "kind": "RoleBinding",
+        "metadata": {"name": "read-pods", "namespace": "default"},
+        "subjects": [
+            {
+                "kind": "User",
+                "name": "jane",
+                "apiGroup": "rbac.authorization.k8s.io"
+            }
+        ],
+        "roleRef": {
+            "apiGroup": "rbac.authorization.k8s.io",
+            "kind": "Role",
+            "name": "pod-reader"
+        }
+    }"#;
+    assert_roundtrip::<RoleBinding>(fixture);
+}
+
+#[test]
+fn roundtrip_rolebinding_service_account_subject() {
+    let fixture = r#"{
+        "apiVersion": "rbac.authorization.k8s.io/v1",
+        "kind": "RoleBinding",
+        "metadata": {"name": "sa-binding", "namespace": "kube-system"},
+        "subjects": [
+            {
+                "kind": "ServiceAccount",
+                "name": "default",
+                "namespace": "kube-system"
+            }
+        ],
+        "roleRef": {
+            "apiGroup": "rbac.authorization.k8s.io",
+            "kind": "Role",
+            "name": "pod-reader"
+        }
+    }"#;
+    assert_roundtrip::<RoleBinding>(fixture);
+}
+
+#[test]
+fn roundtrip_clusterrole_with_non_resource_urls() {
+    let fixture = r#"{
+        "apiVersion": "rbac.authorization.k8s.io/v1",
+        "kind": "ClusterRole",
+        "metadata": {"name": "metrics-reader"},
+        "rules": [
+            {
+                "verbs": ["get"],
+                "nonResourceURLs": ["/metrics", "/healthz", "/livez"]
+            }
+        ]
+    }"#;
+    assert_roundtrip::<ClusterRole>(fixture);
+}
+
+#[test]
+fn roundtrip_clusterrole_with_aggregation_rule() {
+    let fixture = r#"{
+        "apiVersion": "rbac.authorization.k8s.io/v1",
+        "kind": "ClusterRole",
+        "metadata": {"name": "monitoring"},
+        "rules": [],
+        "aggregationRule": {
+            "clusterRoleSelectors": [
+                {
+                    "matchLabels": {"rbac.example.com/aggregate-to-monitoring": "true"}
+                }
+            ]
+        }
+    }"#;
+    assert_roundtrip::<ClusterRole>(fixture);
+}
+
+#[test]
+fn roundtrip_clusterrolebinding_group_subject() {
+    let fixture = r#"{
+        "apiVersion": "rbac.authorization.k8s.io/v1",
+        "kind": "ClusterRoleBinding",
+        "metadata": {"name": "system-monitoring"},
+        "subjects": [
+            {
+                "kind": "Group",
+                "name": "system:monitoring",
+                "apiGroup": "rbac.authorization.k8s.io"
+            }
+        ],
+        "roleRef": {
+            "apiGroup": "rbac.authorization.k8s.io",
+            "kind": "ClusterRole",
+            "name": "view"
+        }
+    }"#;
+    assert_roundtrip::<ClusterRoleBinding>(fixture);
+}
+
+// =============================================================================
+// scheduling.k8s.io/v1
+// =============================================================================
+
+#[test]
+fn roundtrip_priority_class_minimal() {
+    let fixture = r#"{
+        "apiVersion": "scheduling.k8s.io/v1",
+        "kind": "PriorityClass",
+        "metadata": {"name": "high-priority"},
+        "value": 1000000
+    }"#;
+    assert_roundtrip::<PriorityClass>(fixture);
+}
+
+#[test]
+fn roundtrip_priority_class_global_default() {
+    let fixture = r#"{
+        "apiVersion": "scheduling.k8s.io/v1",
+        "kind": "PriorityClass",
+        "metadata": {"name": "default-priority"},
+        "value": 0,
+        "globalDefault": true,
+        "description": "default priority class for all pods"
+    }"#;
+    assert_roundtrip::<PriorityClass>(fixture);
+}
+
+#[test]
+fn roundtrip_priority_class_preempt_never() {
+    let fixture = r#"{
+        "apiVersion": "scheduling.k8s.io/v1",
+        "kind": "PriorityClass",
+        "metadata": {"name": "system-cluster-critical"},
+        "value": 2000000000,
+        "globalDefault": false,
+        "preemptionPolicy": "Never"
+    }"#;
+    assert_roundtrip::<PriorityClass>(fixture);
+}
+
+// =============================================================================
+// storage.k8s.io/v1
+// =============================================================================
+
+#[test]
+fn roundtrip_storage_class_minimal() {
+    let fixture = r#"{
+        "apiVersion": "storage.k8s.io/v1",
+        "kind": "StorageClass",
+        "metadata": {"name": "standard"},
+        "provisioner": "kubernetes.io/no-provisioner"
+    }"#;
+    assert_roundtrip::<StorageClass>(fixture);
+}
+
+#[test]
+fn roundtrip_storage_class_full() {
+    let fixture = r#"{
+        "apiVersion": "storage.k8s.io/v1",
+        "kind": "StorageClass",
+        "metadata": {"name": "fast-ssd"},
+        "provisioner": "kubernetes.io/aws-ebs",
+        "parameters": {"type": "gp3", "iopsPerGB": "10"},
+        "reclaimPolicy": "Delete",
+        "volumeBindingMode": "WaitForFirstConsumer",
+        "allowVolumeExpansion": true,
+        "mountOptions": ["debug", "ro"]
+    }"#;
+    assert_roundtrip::<StorageClass>(fixture);
+}
+
+#[test]
+fn roundtrip_storage_class_with_topology() {
+    let fixture = r#"{
+        "apiVersion": "storage.k8s.io/v1",
+        "kind": "StorageClass",
+        "metadata": {"name": "zonal"},
+        "provisioner": "kubernetes.io/gce-pd",
+        "volumeBindingMode": "Immediate",
+        "allowedTopologies": [
+            {
+                "matchLabelExpressions": [
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "values": ["us-central1-a", "us-central1-b"]
+                    }
+                ]
+            }
+        ]
+    }"#;
+    assert_roundtrip::<StorageClass>(fixture);
+}
+
+#[test]
+fn roundtrip_csi_driver_minimal() {
+    let fixture = r#"{
+        "apiVersion": "storage.k8s.io/v1",
+        "kind": "CSIDriver",
+        "metadata": {"name": "csi.example.com"},
+        "spec": {}
+    }"#;
+    assert_roundtrip::<CSIDriver>(fixture);
+}
+
+#[test]
+fn roundtrip_csi_driver_full() {
+    let fixture = r#"{
+        "apiVersion": "storage.k8s.io/v1",
+        "kind": "CSIDriver",
+        "metadata": {"name": "ebs.csi.aws.com"},
+        "spec": {
+            "attachRequired": true,
+            "podInfoOnMount": true,
+            "fsGroupPolicy": "ReadWriteOnceWithFSType",
+            "storageCapacity": true,
+            "volumeLifecycleModes": ["Persistent", "Ephemeral"],
+            "tokenRequests": [
+                {"audience": "ebs.csi.aws.com", "expirationSeconds": 3600}
+            ],
+            "requiresRepublish": false,
+            "seLinuxMount": true
+        }
+    }"#;
+    assert_roundtrip::<CSIDriver>(fixture);
+}
+
+#[test]
+fn roundtrip_volume_attachment_minimal() {
+    let fixture = r#"{
+        "apiVersion": "storage.k8s.io/v1",
+        "kind": "VolumeAttachment",
+        "metadata": {"name": "csi-attachment-1"},
+        "spec": {
+            "attacher": "csi.example.com",
+            "nodeName": "worker-1",
+            "source": {
+                "persistentVolumeName": "pv-001"
+            }
+        }
+    }"#;
+    assert_roundtrip::<VolumeAttachment>(fixture);
+}
+
+#[test]
+fn roundtrip_volume_attachment_with_status() {
+    let fixture = r#"{
+        "apiVersion": "storage.k8s.io/v1",
+        "kind": "VolumeAttachment",
+        "metadata": {"name": "csi-attachment-2"},
+        "spec": {
+            "attacher": "csi.example.com",
+            "nodeName": "worker-2",
+            "source": {
+                "persistentVolumeName": "pv-002"
+            }
+        },
+        "status": {
+            "attached": true,
+            "attachmentMetadata": {"device": "/dev/sdb"}
+        }
+    }"#;
+    assert_roundtrip::<VolumeAttachment>(fixture);
+}
+
+// =============================================================================
+// node.k8s.io/v1
+// =============================================================================
+
+#[test]
+fn roundtrip_runtime_class_minimal() {
+    let fixture = r#"{
+        "apiVersion": "node.k8s.io/v1",
+        "kind": "RuntimeClass",
+        "metadata": {"name": "runc"},
+        "handler": "runc"
+    }"#;
+    assert_roundtrip::<RuntimeClass>(fixture);
+}
+
+#[test]
+fn roundtrip_runtime_class_with_overhead() {
+    let fixture = r#"{
+        "apiVersion": "node.k8s.io/v1",
+        "kind": "RuntimeClass",
+        "metadata": {"name": "kata"},
+        "handler": "kata-runtime",
+        "overhead": {
+            "podFixed": {"cpu": "250m", "memory": "128Mi"}
+        }
+    }"#;
+    assert_roundtrip::<RuntimeClass>(fixture);
+}
+
+#[test]
+fn roundtrip_runtime_class_with_scheduling() {
+    let fixture = r#"{
+        "apiVersion": "node.k8s.io/v1",
+        "kind": "RuntimeClass",
+        "metadata": {"name": "gvisor"},
+        "handler": "runsc",
+        "scheduling": {
+            "nodeSelector": {"runtime": "gvisor"},
+            "tolerations": [
+                {
+                    "key": "runtime",
+                    "operator": "Equal",
+                    "value": "gvisor",
+                    "effect": "NoSchedule"
+                }
+            ]
+        }
+    }"#;
+    assert_roundtrip::<RuntimeClass>(fixture);
+}
+
+// =============================================================================
+// flowcontrol.apiserver.k8s.io/v1
+// =============================================================================
+
+#[test]
+fn roundtrip_flow_schema_minimal() {
+    let fixture = r#"{
+        "apiVersion": "flowcontrol.apiserver.k8s.io/v1",
+        "kind": "FlowSchema",
+        "metadata": {"name": "exempt"},
+        "spec": {
+            "priorityLevelConfiguration": {"name": "exempt"},
+            "matchingPrecedence": 1
+        }
+    }"#;
+    assert_roundtrip::<FlowSchema>(fixture);
+}
+
+#[test]
+fn roundtrip_flow_schema_with_rules() {
+    let fixture = r#"{
+        "apiVersion": "flowcontrol.apiserver.k8s.io/v1",
+        "kind": "FlowSchema",
+        "metadata": {"name": "system-leader-election"},
+        "spec": {
+            "priorityLevelConfiguration": {"name": "leader-election"},
+            "matchingPrecedence": 200,
+            "distinguisherMethod": {"type": "ByUser"},
+            "rules": [
+                {
+                    "subjects": [
+                        {"kind": "User", "user": {"name": "system:kube-controller-manager"}}
+                    ],
+                    "resourceRules": [
+                        {
+                            "verbs": ["get", "create", "update"],
+                            "apiGroups": ["coordination.k8s.io"],
+                            "resources": ["leases"],
+                            "namespaces": ["kube-system"]
+                        }
+                    ]
+                }
+            ]
+        }
+    }"#;
+    assert_roundtrip::<FlowSchema>(fixture);
+}
+
+#[test]
+fn roundtrip_priority_level_configuration_exempt() {
+    let fixture = r#"{
+        "apiVersion": "flowcontrol.apiserver.k8s.io/v1",
+        "kind": "PriorityLevelConfiguration",
+        "metadata": {"name": "exempt"},
+        "spec": {
+            "type": "Exempt",
+            "exempt": {
+                "nominalConcurrencyShares": 0,
+                "lendingConcurrencyLimit": 0
+            }
+        }
+    }"#;
+    assert_roundtrip::<PriorityLevelConfiguration>(fixture);
+}
+
+#[test]
+fn roundtrip_priority_level_configuration_limited_queue() {
+    let fixture = r#"{
+        "apiVersion": "flowcontrol.apiserver.k8s.io/v1",
+        "kind": "PriorityLevelConfiguration",
+        "metadata": {"name": "workload-low"},
+        "spec": {
+            "type": "Limited",
+            "limited": {
+                "nominalConcurrencyShares": 100,
+                "borrowingLimitPercent": 50,
+                "limitResponse": {
+                    "type": "Queue",
+                    "queuing": {
+                        "queues": 128,
+                        "handSize": 6,
+                        "queueLengthLimit": 50
+                    }
+                }
+            }
+        }
+    }"#;
+    assert_roundtrip::<PriorityLevelConfiguration>(fixture);
+}
+
+#[test]
+fn roundtrip_priority_level_configuration_limited_reject() {
+    let fixture = r#"{
+        "apiVersion": "flowcontrol.apiserver.k8s.io/v1",
+        "kind": "PriorityLevelConfiguration",
+        "metadata": {"name": "catch-all"},
+        "spec": {
+            "type": "Limited",
+            "limited": {
+                "nominalConcurrencyShares": 5,
+                "limitResponse": {
+                    "type": "Reject"
+                }
+            }
+        }
+    }"#;
+    assert_roundtrip::<PriorityLevelConfiguration>(fixture);
+}
+
+// =============================================================================
+// admissionregistration.k8s.io/v1
+// =============================================================================
+
+#[test]
+fn roundtrip_validating_webhook_configuration_minimal() {
+    let fixture = r#"{
+        "apiVersion": "admissionregistration.k8s.io/v1",
+        "kind": "ValidatingWebhookConfiguration",
+        "metadata": {"name": "validate-pods"}
+    }"#;
+    assert_roundtrip::<ValidatingWebhookConfiguration>(fixture);
+}
+
+#[test]
+fn roundtrip_validating_webhook_configuration_with_service() {
+    let fixture = r#"{
+        "apiVersion": "admissionregistration.k8s.io/v1",
+        "kind": "ValidatingWebhookConfiguration",
+        "metadata": {"name": "validate-pods"},
+        "webhooks": [
+            {
+                "name": "pod-validator.example.com",
+                "clientConfig": {
+                    "service": {
+                        "namespace": "example",
+                        "name": "pod-validator",
+                        "path": "/validate",
+                        "port": 443
+                    },
+                    "caBundle": "Zm9vYmFy"
+                },
+                "rules": [
+                    {
+                        "operations": ["CREATE", "UPDATE"],
+                        "apiGroups": [""],
+                        "apiVersions": ["v1"],
+                        "resources": ["pods"],
+                        "scope": "Namespaced"
+                    }
+                ],
+                "failurePolicy": "Fail",
+                "matchPolicy": "Equivalent",
+                "sideEffects": "None",
+                "timeoutSeconds": 10,
+                "admissionReviewVersions": ["v1"]
+            }
+        ]
+    }"#;
+    assert_roundtrip::<ValidatingWebhookConfiguration>(fixture);
+}
+
+#[test]
+fn roundtrip_validating_webhook_configuration_with_url_and_selector() {
+    let fixture = r#"{
+        "apiVersion": "admissionregistration.k8s.io/v1",
+        "kind": "ValidatingWebhookConfiguration",
+        "metadata": {"name": "validate-external"},
+        "webhooks": [
+            {
+                "name": "external.example.com",
+                "clientConfig": {
+                    "url": "https://example.com/validate"
+                },
+                "rules": [
+                    {
+                        "operations": ["*"],
+                        "apiGroups": ["apps"],
+                        "apiVersions": ["v1"],
+                        "resources": ["deployments"]
+                    }
+                ],
+                "namespaceSelector": {
+                    "matchLabels": {"env": "prod"}
+                },
+                "objectSelector": {
+                    "matchExpressions": [
+                        {"key": "skip-validation", "operator": "DoesNotExist"}
+                    ]
+                },
+                "sideEffects": "NoneOnDryRun",
+                "admissionReviewVersions": ["v1"],
+                "matchConditions": [
+                    {"name": "exclude-system", "expression": "request.userInfo.username != 'system:serviceaccount:kube-system:default'"}
+                ]
+            }
+        ]
+    }"#;
+    assert_roundtrip::<ValidatingWebhookConfiguration>(fixture);
+}
+
+#[test]
+fn roundtrip_mutating_webhook_configuration_minimal() {
+    let fixture = r#"{
+        "apiVersion": "admissionregistration.k8s.io/v1",
+        "kind": "MutatingWebhookConfiguration",
+        "metadata": {"name": "mutate-pods"}
+    }"#;
+    assert_roundtrip::<MutatingWebhookConfiguration>(fixture);
+}
+
+#[test]
+fn roundtrip_mutating_webhook_configuration_reinvocation_if_needed() {
+    let fixture = r#"{
+        "apiVersion": "admissionregistration.k8s.io/v1",
+        "kind": "MutatingWebhookConfiguration",
+        "metadata": {"name": "sidecar-injector"},
+        "webhooks": [
+            {
+                "name": "sidecar-injector.example.com",
+                "clientConfig": {
+                    "service": {
+                        "namespace": "istio-system",
+                        "name": "sidecar-injector",
+                        "path": "/inject"
+                    }
+                },
+                "rules": [
+                    {
+                        "operations": ["CREATE"],
+                        "apiGroups": [""],
+                        "apiVersions": ["v1"],
+                        "resources": ["pods"]
+                    }
+                ],
+                "failurePolicy": "Ignore",
+                "sideEffects": "None",
+                "admissionReviewVersions": ["v1"],
+                "reinvocationPolicy": "IfNeeded"
+            }
+        ]
+    }"#;
+    assert_roundtrip::<MutatingWebhookConfiguration>(fixture);
+}
+
+// =============================================================================
+// apiextensions.k8s.io/v1
+// =============================================================================
+
+#[test]
+fn roundtrip_crd_minimal_namespaced() {
+    let fixture = r#"{
+        "apiVersion": "apiextensions.k8s.io/v1",
+        "kind": "CustomResourceDefinition",
+        "metadata": {"name": "crontabs.stable.example.com"},
+        "spec": {
+            "group": "stable.example.com",
+            "names": {
+                "plural": "crontabs",
+                "singular": "crontab",
+                "kind": "CronTab",
+                "listKind": "CronTabList"
+            },
+            "scope": "Namespaced",
+            "versions": [
+                {"name": "v1", "served": true, "storage": true}
+            ]
+        }
+    }"#;
+    assert_roundtrip::<CustomResourceDefinition>(fixture);
+}
+
+#[test]
+fn roundtrip_crd_cluster_scoped_with_short_names() {
+    let fixture = r#"{
+        "apiVersion": "apiextensions.k8s.io/v1",
+        "kind": "CustomResourceDefinition",
+        "metadata": {"name": "clusterthings.stable.example.com"},
+        "spec": {
+            "group": "stable.example.com",
+            "names": {
+                "plural": "clusterthings",
+                "kind": "ClusterThing",
+                "shortNames": ["ct", "cthing"],
+                "categories": ["all", "cluster"]
+            },
+            "scope": "Cluster",
+            "versions": [
+                {"name": "v1", "served": true, "storage": true}
+            ]
+        }
+    }"#;
+    assert_roundtrip::<CustomResourceDefinition>(fixture);
+}
+
+#[test]
+fn roundtrip_crd_with_schema_and_subresources() {
+    let fixture = r#"{
+        "apiVersion": "apiextensions.k8s.io/v1",
+        "kind": "CustomResourceDefinition",
+        "metadata": {"name": "widgets.example.com"},
+        "spec": {
+            "group": "example.com",
+            "names": {
+                "plural": "widgets",
+                "kind": "Widget"
+            },
+            "scope": "Namespaced",
+            "versions": [
+                {
+                    "name": "v1",
+                    "served": true,
+                    "storage": true,
+                    "schema": {
+                        "openAPIV3Schema": {
+                            "type": "object",
+                            "properties": {
+                                "spec": {
+                                    "type": "object",
+                                    "required": ["replicas"],
+                                    "properties": {
+                                        "replicas": {
+                                            "type": "integer",
+                                            "minimum": 0
+                                        },
+                                        "color": {
+                                            "type": "string",
+                                            "enum": ["red", "green", "blue"]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "subresources": {
+                        "status": {},
+                        "scale": {
+                            "specReplicasPath": ".spec.replicas",
+                            "statusReplicasPath": ".status.replicas",
+                            "labelSelectorPath": ".status.labelSelector"
+                        }
+                    },
+                    "additionalPrinterColumns": [
+                        {"name": "Replicas", "type": "integer", "jsonPath": ".spec.replicas"}
+                    ]
+                }
+            ]
+        }
+    }"#;
+    assert_roundtrip::<CustomResourceDefinition>(fixture);
+}
+
+#[test]
+fn roundtrip_crd_with_webhook_conversion() {
+    let fixture = r#"{
+        "apiVersion": "apiextensions.k8s.io/v1",
+        "kind": "CustomResourceDefinition",
+        "metadata": {"name": "things.example.com"},
+        "spec": {
+            "group": "example.com",
+            "names": {
+                "plural": "things",
+                "kind": "Thing"
+            },
+            "scope": "Namespaced",
+            "versions": [
+                {"name": "v1", "served": true, "storage": false},
+                {"name": "v2", "served": true, "storage": true}
+            ],
+            "conversion": {
+                "strategy": "Webhook",
+                "webhook": {
+                    "clientConfig": {
+                        "service": {
+                            "namespace": "example",
+                            "name": "conversion-webhook",
+                            "path": "/convert"
+                        }
+                    },
+                    "conversionReviewVersions": ["v1"]
+                }
+            }
+        }
+    }"#;
+    assert_roundtrip::<CustomResourceDefinition>(fixture);
+}


### PR DESCRIPTION
## Summary

Mirror upstream Kubernetes' apimachinery roundtrip test layer (\`staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/\`) by verifying that every major resource can survive a JSON encode → decode → encode → decode cycle without mutation.

5 new files, +4753 LOC, **pure test additions — no production code touched**:

| File | Tests | Coverage |
|------|-------|----------|
| `tests/roundtrip_core_v1.rs` | 62 | Pod, ConfigMap, Secret, Service, Namespace, Node, Event, ServiceAccount, PV, PVC, Endpoints, LimitRange, ResourceQuota |
| `tests/roundtrip_apps_v1.rs` | 26 | Deployment, ReplicaSet, StatefulSet, DaemonSet, ControllerRevision |
| `tests/roundtrip_batch.rs` | 25 | Job, CronJob, autoscaling/v1+v2 HPA, PodDisruptionBudget |
| `tests/roundtrip_networking.rs` | 28 | Ingress, IngressClass, NetworkPolicy, EndpointSlice, Service-related |
| `tests/roundtrip_rbac_storage.rs` | 34 | Role, ClusterRole, RoleBinding, StorageClass, VolumeAttachment, PriorityClass, MutatingWebhookConfig, ValidatingWebhookConfig, CRD, FlowSchema, PriorityLevelConfig |

Fixtures are hand-written camelCase JSON exercising minimal payloads, full-featured shapes, status subresources, list wrappers, and edge cases (IntOrString variants, Recreate/OnDelete strategies, percent vs int ScaleTargetSelector, etc).

Equality is asserted via \`serde_json::Value\` rather than \`PartialEq\` — many core/v1 structs (Pod, Service, Node, …) don't currently derive \`PartialEq\`, and \"wire shape survives\" is precisely the property this layer is meant to guarantee (matching upstream Go practice).

## Test plan

- [x] \`cargo test -p rusternetes-common --test roundtrip_core_v1\` — 62/62
- [x] \`cargo test -p rusternetes-common --test roundtrip_apps_v1\` — 26/26
- [x] \`cargo test -p rusternetes-common --test roundtrip_batch\` — 25/25
- [x] \`cargo test -p rusternetes-common --test roundtrip_networking\` — 28/28
- [x] \`cargo test -p rusternetes-common --test roundtrip_rbac_storage\` — 34/34
- [x] \`cargo fmt --all -- --check\` clean