### PR TITLE
fix(api-server): strict-field 400/BadRequest + Warn:299 + default=Strict

### DIFF
--- a/crates/api-server/src/handlers/deployment.rs
+++ b/crates/api-server/src/handlers/deployment.rs
@@ -22,26 +22,25 @@ pub async fn create(
     Path(namespace): Path<String>,
     Query(params): Query<HashMap<String, String>>,
     body: Bytes,
-) -> Result<(StatusCode, Json<Deployment>)> {
-    // Parse the body manually so we can do strict field validation against the raw bytes.
-    // For strict mode, if serde_json errors on duplicate fields, parse via serde_json::Value
-    // first (which is lenient) and then re-parse as Deployment, so validate_strict_fields
-    // can report all issues (unknown + duplicate) in the correct K8s format.
-    let is_strict = params.get("fieldValidation").map(|v| v.as_str()) == Some("Strict");
+) -> Result<(StatusCode, HeaderMap, Json<Deployment>)> {
+    // Parse the body manually so we can do strict field validation against the
+    // raw bytes. In any mode that may need to report duplicate keys (Strict —
+    // now the K8s 1.25+ default — or Warn) we re-parse via serde_json::Value
+    // so validate_strict_fields can report unknown + duplicate issues in the
+    // canonical `strict decoding error: ...` format.
     let mut deployment: Deployment = match serde_json::from_slice(&body) {
         Ok(d) => d,
         Err(e) => {
             let msg = e.to_string();
-            if is_strict && msg.contains("duplicate field") {
-                // Parse via Value (lenient — takes last duplicate) so validate_strict_fields runs
+            if msg.contains("duplicate field") {
                 let value: serde_json::Value = serde_json::from_slice(&body).map_err(|e2| {
-                    rusternetes_common::Error::InvalidResource(format!("failed to decode: {}", e2))
+                    rusternetes_common::Error::BadRequest(format!("failed to decode: {}", e2))
                 })?;
                 serde_json::from_value(value).map_err(|e2| {
-                    rusternetes_common::Error::InvalidResource(format!("failed to decode: {}", e2))
+                    rusternetes_common::Error::BadRequest(format!("failed to decode: {}", e2))
                 })?
             } else {
-                return Err(rusternetes_common::Error::InvalidResource(format!(
+                return Err(rusternetes_common::Error::BadRequest(format!(
                     "failed to decode: {}",
                     msg
                 )));
@@ -54,8 +53,12 @@ pub async fn create(
         namespace, deployment.metadata.name
     );
 
-    // Strict field validation: reject unknown fields when requested
-    crate::handlers::validation::validate_strict_fields(&params, &body, &deployment)?;
+    // Strict field validation: reject unknown fields when requested. Warn
+    // mode surfaces warnings as `Warning: 299` response headers (per RFC
+    // 7234), matching upstream apimachinery util/warning behaviour.
+    let warnings =
+        crate::handlers::validation::validate_strict_fields(&params, &body, &deployment)?;
+    let response_headers = build_warning_headers(&warnings);
 
     // Check if this is a dry-run request
     let is_dry_run = crate::handlers::dryrun::is_dry_run(&params);
@@ -117,12 +120,26 @@ pub async fn create(
             "Dry-run: Deployment {}/{} validated successfully (not created)",
             namespace, deployment.metadata.name
         );
-        return Ok((StatusCode::CREATED, Json(deployment)));
+        return Ok((StatusCode::CREATED, response_headers, Json(deployment)));
     }
 
     let created = state.storage.create(&key, &deployment).await?;
 
-    Ok((StatusCode::CREATED, Json(created)))
+    Ok((StatusCode::CREATED, response_headers, Json(created)))
+}
+
+/// Convert the `validate_strict_fields` warning strings into a `HeaderMap`
+/// holding RFC 7234 `Warning: 299 - "..."` entries. Empty input → empty map,
+/// which keeps response shape identical for non-Warn callers.
+fn build_warning_headers(warnings: &[String]) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    for warning in warnings {
+        let value = crate::handlers::validation::format_warning_header(warning);
+        if let Ok(hv) = axum::http::HeaderValue::from_str(&value) {
+            headers.append(axum::http::header::WARNING, hv);
+        }
+    }
+    headers
 }
 
 pub async fn get(

--- a/crates/api-server/src/handlers/pod.rs
+++ b/crates/api-server/src/handlers/pod.rs
@@ -26,16 +26,56 @@ pub async fn create(
     Path(namespace): Path<String>,
     axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
     body: Bytes,
-) -> Result<(StatusCode, Json<Pod>)> {
-    // Parse the body manually so we can do strict field validation against the raw bytes
-    let mut pod: Pod = serde_json::from_slice(&body).map_err(|e| {
-        rusternetes_common::Error::InvalidResource(format!("failed to decode: {}", e))
-    })?;
+) -> Result<(StatusCode, HeaderMap, Json<Pod>)> {
+    // Parse the body manually so we can do strict field validation against the
+    // raw bytes. In strict mode (now the K8s 1.25+ default) serde_json will
+    // reject duplicate keys outright — fall back to a lenient Value parse so
+    // validate_strict_fields can report the duplicate in the canonical
+    // `strict decoding error: duplicate field "..."` shape rather than a raw
+    // serde error.
+    let is_lenient = matches!(
+        crate::handlers::validation::FieldValidationMode::from_query(&params),
+        crate::handlers::validation::FieldValidationMode::Warn
+            | crate::handlers::validation::FieldValidationMode::Ignore
+    );
+    let mut pod: Pod = match serde_json::from_slice(&body) {
+        Ok(p) => p,
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("duplicate field") {
+                // Re-parse via Value (lenient — takes last duplicate) so the
+                // strict-decode error path can synthesize a parity-shaped
+                // message that names every duplicate.
+                let value: serde_json::Value = serde_json::from_slice(&body).map_err(|e2| {
+                    rusternetes_common::Error::BadRequest(format!("failed to decode: {}", e2))
+                })?;
+                serde_json::from_value(value).map_err(|e2| {
+                    rusternetes_common::Error::BadRequest(format!("failed to decode: {}", e2))
+                })?
+            } else if is_lenient {
+                // Warn / Ignore mode: even ordinary decode failures shouldn't
+                // mask the user's intent — but if the body is unparseable we
+                // can't continue at all, so still error.
+                return Err(rusternetes_common::Error::BadRequest(format!(
+                    "failed to decode: {}",
+                    msg
+                )));
+            } else {
+                return Err(rusternetes_common::Error::BadRequest(format!(
+                    "failed to decode: {}",
+                    msg
+                )));
+            }
+        }
+    };
 
     info!("Creating pod: {}/{}", namespace, pod.metadata.name);
 
-    // Strict field validation: reject unknown fields when requested
-    crate::handlers::validation::validate_strict_fields(&params, &body, &pod)?;
+    // Strict field validation: reject unknown fields when requested. Warn
+    // mode returns one warning string per unknown field; the handler turns
+    // those into `Warning: 299 - "..."` response headers below.
+    let warnings = crate::handlers::validation::validate_strict_fields(&params, &body, &pod)?;
+    let response_headers = build_warning_headers(&warnings);
 
     // Check if this is a dry-run request
     let is_dry_run = crate::handlers::dryrun::is_dry_run(&params);
@@ -571,7 +611,7 @@ pub async fn create(
             "Dry-run: Pod {}/{} validated successfully (not created)",
             namespace, pod.metadata.name
         );
-        return Ok((StatusCode::CREATED, Json(pod)));
+        return Ok((StatusCode::CREATED, response_headers, Json(pod)));
     }
 
     match state.storage.create(&key, &pod).await {
@@ -580,7 +620,7 @@ pub async fn create(
                 "Pod created successfully: {}/{}",
                 namespace, pod.metadata.name
             );
-            Ok((StatusCode::CREATED, Json(created)))
+            Ok((StatusCode::CREATED, response_headers, Json(created)))
         }
         Err(e) => {
             warn!(
@@ -590,6 +630,20 @@ pub async fn create(
             Err(e)
         }
     }
+}
+
+/// Convert the `validate_strict_fields` warning strings into a `HeaderMap`
+/// holding RFC 7234 `Warning: 299 - "..."` entries. Empty input → empty map,
+/// which keeps response shape identical for non-Warn callers.
+fn build_warning_headers(warnings: &[String]) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    for warning in warnings {
+        let value = crate::handlers::validation::format_warning_header(warning);
+        if let Ok(hv) = axum::http::HeaderValue::from_str(&value) {
+            headers.append(axum::http::header::WARNING, hv);
+        }
+    }
+    headers
 }
 
 pub async fn get(

--- a/crates/api-server/src/handlers/validation.rs
+++ b/crates/api-server/src/handlers/validation.rs
@@ -364,67 +364,146 @@ fn find_unknown_fields_recursive(
     }
 }
 
-/// When `fieldValidation=Strict` is set, validate that the request body does not
-/// contain unknown or duplicate fields. Unknown fields are detected by comparing
-/// the original JSON against a re-serialized version of the parsed struct.
-/// Duplicate fields are detected by scanning the raw JSON.
-/// All errors are combined into a single message matching the Kubernetes format:
-/// `strict decoding error: unknown field "spec.foo", duplicate field "spec.bar"`
+/// Field-validation mode resolved from the `?fieldValidation=` query param.
+///
+/// Mirrors upstream k8s `apimachinery/pkg/runtime/serializer/json/json.go`
+/// validation directive parsing. Starting with Kubernetes 1.25 (`PR #107807`,
+/// promoted to GA in 1.27), the server-side default when the param is absent
+/// is `Strict`. Earlier clients that omit the param therefore now get the same
+/// behaviour as if they had asked for it explicitly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FieldValidationMode {
+    /// Reject unknown / duplicate fields with a 400 BadRequest.
+    Strict,
+    /// Accept unknown fields but emit a `Warning: 299` response header per
+    /// offending field path.
+    Warn,
+    /// Accept unknown fields silently (drop them on read-back).
+    Ignore,
+}
+
+impl FieldValidationMode {
+    /// Resolve the mode from the query param map, defaulting to `Strict` when
+    /// the param is absent. Unknown values fall back to `Strict` to match
+    /// upstream's conservative behaviour.
+    pub fn from_query(params: &HashMap<String, String>) -> Self {
+        match params.get("fieldValidation").map(|v| v.as_str()) {
+            Some("Warn") => Self::Warn,
+            Some("Ignore") => Self::Ignore,
+            // Strict, missing, or unknown values: default to Strict per
+            // K8s 1.25+ server-side default.
+            _ => Self::Strict,
+        }
+    }
+}
+
+/// Build the canonical `strict decoding error: ...` message from the collected
+/// unknown / duplicate field paths.
+fn build_strict_decoding_message(unknown: &[String], duplicates: &[String]) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    for field in unknown {
+        parts.push(format!("unknown field \"{}\"", field));
+    }
+    for field in duplicates {
+        parts.push(format!("duplicate field \"{}\"", field));
+    }
+    format!("strict decoding error: {}", parts.join(", "))
+}
+
+/// Validate the request body against the parsed resource per the
+/// `?fieldValidation=` directive.
+///
+/// Behaviour by mode (matches upstream k8s 1.35):
+/// - `Strict` (or absent param, since 1.25): unknown / duplicate fields are
+///   rejected with `Error::BadRequest` → HTTP 400 reason=BadRequest. Message
+///   format: `strict decoding error: unknown field "spec.foo", duplicate field
+///   "spec.bar"`.
+/// - `Warn`: unknown fields are returned in the `Ok(Vec<String>)` so the
+///   handler can emit one `Warning: 299 - "..."` response header per field.
+///   Duplicate fields are NOT enforced in Warn mode (matches upstream — only
+///   strict decoding splits on duplicates).
+/// - `Ignore`: empty vec, no enforcement.
+///
+/// On success the returned vector contains zero or more `unknown field "..."`
+/// strings ready to be wrapped in the RFC 7234 Warning header value.
 pub fn validate_strict_fields(
     params: &HashMap<String, String>,
     original_body: &[u8],
     parsed_resource: &impl serde::Serialize,
-) -> Result<(), Error> {
-    if params.get("fieldValidation").map(|v| v.as_str()) != Some("Strict") {
-        return Ok(());
+) -> Result<Vec<String>, Error> {
+    let mode = FieldValidationMode::from_query(params);
+    if matches!(mode, FieldValidationMode::Ignore) {
+        return Ok(Vec::new());
     }
 
-    let mut error_parts: Vec<String> = Vec::new();
-
-    // Parse original as generic JSON
+    // Parse original as generic JSON. A serde_json failure here is a true
+    // syntactic error → BadRequest regardless of mode (matches upstream:
+    // duplicate-field detection at the decoder level can't be downgraded by
+    // ?fieldValidation=Warn).
     let original: serde_json::Value = serde_json::from_slice(original_body).map_err(|e| {
         let msg = e.to_string();
         if msg.contains("duplicate field") {
             if let Some(field) = msg.split('`').nth(1) {
-                return Error::InvalidResource(format!(
+                return Error::BadRequest(format!(
                     "strict decoding error: json: unknown field \"{}\"",
                     field
                 ));
             }
         }
-        Error::InvalidResource(msg)
+        Error::BadRequest(msg)
     })?;
 
-    // Re-serialize the parsed struct to get canonical JSON
+    // Re-serialize the parsed struct to get canonical JSON.
     let canonical =
         serde_json::to_value(parsed_resource).map_err(|e| Error::Internal(e.to_string()))?;
 
-    // Find unknown fields recursively
+    // Collect unknown field paths.
     let mut unknown = Vec::new();
     find_unknown_fields_recursive(&original, &canonical, "", &mut unknown);
 
-    // Add unknown field errors
-    for field in &unknown {
-        error_parts.push(format!("unknown field \"{}\"", field));
-    }
+    // Collect duplicate field paths from the raw bytes (serde_json silently
+    // takes the last duplicate so we must rescan).
+    let duplicates: Vec<String> = std::str::from_utf8(original_body)
+        .map(find_all_duplicate_json_keys)
+        .unwrap_or_default();
 
-    // Check for duplicate keys in the JSON body
-    // serde_json silently takes the last value for duplicates, so we must detect manually
-    if let Ok(body_str) = std::str::from_utf8(original_body) {
-        let dup_fields = find_all_duplicate_json_keys(body_str);
-        for dup_field in &dup_fields {
-            error_parts.push(format!("duplicate field \"{}\"", dup_field));
+    match mode {
+        FieldValidationMode::Strict => {
+            if unknown.is_empty() && duplicates.is_empty() {
+                return Ok(Vec::new());
+            }
+            Err(Error::BadRequest(build_strict_decoding_message(
+                &unknown,
+                &duplicates,
+            )))
         }
+        FieldValidationMode::Warn => {
+            // Warn mode: unknown fields become per-field warnings. Drop
+            // duplicates here — Warn does not surface duplicate keys (they
+            // would have already been merged by serde_json without raising).
+            Ok(unknown
+                .into_iter()
+                .map(|field| format!("unknown field \"{}\"", field))
+                .collect())
+        }
+        FieldValidationMode::Ignore => Ok(Vec::new()), // unreachable, handled above
     }
+}
 
-    if !error_parts.is_empty() {
-        return Err(Error::InvalidResource(format!(
-            "strict decoding error: {}",
-            error_parts.join(", ")
-        )));
-    }
-
-    Ok(())
+/// Build the RFC 7234 `Warning` header value for an unknown-field warning.
+///
+/// Upstream k8s (`apimachinery/pkg/util/warning/warning.go`) uses warn-code
+/// `299` ("Miscellaneous persistent warning") and the agent token `-` to mean
+/// "no agent identifier". Each unknown field becomes one header value:
+///
+/// ```text
+/// Warning: 299 - "unknown field \"spec.foo\""
+/// ```
+pub fn format_warning_header(warning_text: &str) -> String {
+    // `299 <agent> "<quoted-string>"` — agent token `-` is used when no
+    // host:port identifier is available, matching upstream.
+    let escaped = warning_text.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("299 - \"{}\"", escaped)
 }
 
 /// Validate that a resource name is a valid DNS subdomain name (RFC 1123).
@@ -596,7 +675,8 @@ mod tests {
         let mut params = HashMap::new();
         params.insert("fieldValidation".to_string(), "Strict".to_string());
 
-        assert!(validate_strict_fields(&params, body, &parsed).is_ok());
+        let warnings = validate_strict_fields(&params, body, &parsed).unwrap();
+        assert!(warnings.is_empty(), "no warnings on clean body");
     }
 
     #[test]
@@ -653,7 +733,9 @@ mod tests {
     }
 
     #[test]
-    fn test_strict_validation_not_strict_mode_allows_unknown() {
+    fn test_strict_validation_default_is_strict() {
+        // K8s 1.25+ default: missing ?fieldValidation= behaves like
+        // ?fieldValidation=Strict, so unknown fields must be rejected.
         #[derive(serde::Serialize, serde::Deserialize)]
         struct Simple {
             name: String,
@@ -665,12 +747,39 @@ mod tests {
         };
         let params = HashMap::new(); // no fieldValidation param
 
-        // Should pass since not in strict mode
-        assert!(validate_strict_fields(&params, body, &parsed).is_ok());
+        let result = validate_strict_fields(&params, body, &parsed);
+        assert!(
+            result.is_err(),
+            "default mode must reject unknown fields (K8s 1.25+ default is Strict)"
+        );
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(
+            err_msg.contains("strict decoding error") && err_msg.contains("unknown field"),
+            "default rejection should match strict decoder format: {}",
+            err_msg
+        );
     }
 
     #[test]
-    fn test_strict_validation_warn_mode_allows_unknown() {
+    fn test_strict_validation_ignore_mode_allows_unknown() {
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct Simple {
+            name: String,
+        }
+
+        let body = br#"{"name": "test", "extra": "field"}"#;
+        let parsed = Simple {
+            name: "test".to_string(),
+        };
+        let mut params = HashMap::new();
+        params.insert("fieldValidation".to_string(), "Ignore".to_string());
+
+        let warnings = validate_strict_fields(&params, body, &parsed).unwrap();
+        assert!(warnings.is_empty(), "Ignore mode must not surface warnings");
+    }
+
+    #[test]
+    fn test_strict_validation_warn_mode_returns_warnings() {
         #[derive(serde::Serialize, serde::Deserialize)]
         struct Simple {
             name: String,
@@ -683,8 +792,14 @@ mod tests {
         let mut params = HashMap::new();
         params.insert("fieldValidation".to_string(), "Warn".to_string());
 
-        // Should pass since Warn mode, not Strict
-        assert!(validate_strict_fields(&params, body, &parsed).is_ok());
+        // Warn mode must surface unknown fields as warning strings (no error).
+        let warnings = validate_strict_fields(&params, body, &parsed).unwrap();
+        assert_eq!(warnings.len(), 1);
+        assert!(
+            warnings[0].contains("unknown field") && warnings[0].contains("extra"),
+            "warning must identify the unknown field: {:?}",
+            warnings
+        );
     }
 
     #[test]
@@ -803,5 +918,56 @@ mod tests {
         let json = r#"{"spec": {"replicas": 1, "replicas": 2}}"#;
         let dups = find_all_duplicate_json_keys(json);
         assert_eq!(dups, vec!["spec.replicas".to_string()]);
+    }
+
+    #[test]
+    fn test_format_warning_header_shape() {
+        // Upstream emits `Warning: 299 - "..."` per RFC 7234.
+        let header = format_warning_header(r#"unknown field "spec.bogus""#);
+        assert!(
+            header.starts_with("299 "),
+            "header must start with warn-code 299: {}",
+            header
+        );
+        assert!(
+            header.contains("spec.bogus"),
+            "header must mention the unknown field: {}",
+            header
+        );
+        assert!(
+            header.contains(r#"\"spec.bogus\""#),
+            "field name should be quoted/escaped: {}",
+            header
+        );
+    }
+
+    #[test]
+    fn test_field_validation_mode_from_query_defaults_to_strict() {
+        let empty = HashMap::new();
+        assert_eq!(
+            FieldValidationMode::from_query(&empty),
+            FieldValidationMode::Strict
+        );
+
+        let mut warn = HashMap::new();
+        warn.insert("fieldValidation".to_string(), "Warn".to_string());
+        assert_eq!(
+            FieldValidationMode::from_query(&warn),
+            FieldValidationMode::Warn
+        );
+
+        let mut ignore = HashMap::new();
+        ignore.insert("fieldValidation".to_string(), "Ignore".to_string());
+        assert_eq!(
+            FieldValidationMode::from_query(&ignore),
+            FieldValidationMode::Ignore
+        );
+
+        let mut strict = HashMap::new();
+        strict.insert("fieldValidation".to_string(), "Strict".to_string());
+        assert_eq!(
+            FieldValidationMode::from_query(&strict),
+            FieldValidationMode::Strict
+        );
     }
 }

--- a/crates/api-server/tests/decoder_strict_fields_test.rs
+++ b/crates/api-server/tests/decoder_strict_fields_test.rs
@@ -340,11 +340,9 @@ async fn test_field_validation_strict_deployment_duplicate_field_rejected() {
 
 #[tokio::test]
 async fn test_field_validation_strict_status_body_reason_invalid() {
-    // Upstream returns a Status object with reason = "BadRequest" (HTTP 400).
-    // Rusternetes routes strict-decode errors through `Error::InvalidResource`
-    // which produces reason = "Invalid" (HTTP 422). Pin the *actual* contract
-    // so any future change is intentional — and document the upstream-parity
-    // gap explicitly inline.
+    // After unit #7 fixed the strict-decode status mapping, rusternetes now
+    // matches upstream: HTTP 400 with reason=BadRequest. Test name preserved
+    // for blame history; behaviour asserts the post-fix contract.
     let (_mem, router) = spawn_router();
     let mut stub = pod_stub("pod-status-shape");
     stub["spec"]["bogus"] = json!("x");
@@ -354,22 +352,17 @@ async fn test_field_validation_strict_status_body_reason_invalid() {
 
     assert_eq!(
         status,
-        StatusCode::UNPROCESSABLE_ENTITY,
-        "rusternetes currently returns 422 for strict decode failures"
+        StatusCode::BAD_REQUEST,
+        "strict decode failures must map to HTTP 400 per upstream parity"
     );
     assert_eq!(body["kind"], "Status");
     assert_eq!(body["apiVersion"], "v1");
     assert_eq!(body["status"], "Failure");
-    assert_eq!(
-        body["reason"], "Invalid",
-        "rusternetes uses reason=Invalid; upstream uses BadRequest (issue #TBD)"
-    );
-    assert_eq!(body["code"], 422);
+    assert_eq!(body["reason"], "BadRequest");
+    assert_eq!(body["code"], 400);
 }
 
 #[tokio::test]
-#[ignore = "blocked on issue #TBD: rusternetes returns HTTP 422 reason=Invalid for strict \
-            decode failures; upstream k8s 1.35 returns HTTP 400 reason=BadRequest"]
 async fn test_field_validation_strict_returns_400_badrequest_upstream_parity() {
     let (_mem, router) = spawn_router();
     let mut stub = pod_stub("pod-upstream-parity");
@@ -415,8 +408,6 @@ async fn test_field_validation_warn_pod_unknown_field_accepted() {
 }
 
 #[tokio::test]
-#[ignore = "blocked on issue #TBD: Warn mode does not emit Warning: 299 headers \
-            (validate_strict_fields short-circuits for non-Strict modes)"]
 async fn test_field_validation_warn_pod_emits_warning_header() {
     let (_mem, router) = spawn_router();
     let mut stub = pod_stub("pod-warn-header");
@@ -526,35 +517,27 @@ async fn test_field_validation_ignore_deployment_unknown_field_silently_accepted
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn test_field_validation_default_pod_unknown_field_currently_accepted() {
-    // Pin rusternetes's *current* default behaviour: with no fieldValidation
-    // query param, the validator short-circuits at validation.rs:378-380 and
-    // unknown fields are silently dropped. This matches kubectl pre-1.25 and
-    // upstream's `Ignore` mode, NOT the modern server-side default of Strict.
+async fn test_field_validation_default_pod_clean_body_accepted() {
+    // After unit #7 flipped the default to Strict, the no-param + clean-body
+    // path must still succeed. This is the regression guard for the default
+    // change: only *unknown* fields should be rejected, valid bodies pass
+    // through.
     let (_mem, router) = spawn_router();
-    let mut stub = pod_stub("pod-default");
-    stub["spec"]["bogusField"] = json!("nope");
+    let stub = pod_stub("pod-default-clean");
     let uri = pod_uri();
 
     let (status, _hdrs, body) = send_json(router, Method::POST, &uri, &stub).await;
 
     assert!(
         status.is_success(),
-        "current default is non-strict; expected 2xx, got {}: body={}",
+        "clean body must succeed under default-Strict; got {}: body={}",
         status,
         body
     );
-    assert!(
-        body["spec"].get("bogusField").is_none(),
-        "unknown field is dropped: {}",
-        body["spec"]
-    );
+    assert_eq!(body["metadata"]["name"], "pod-default-clean");
 }
 
 #[tokio::test]
-#[ignore = "blocked on issue #TBD: default fieldValidation should be Strict per K8s 1.35; \
-            rusternetes currently defaults to Ignore (validate_strict_fields short-circuits \
-            on missing param)"]
 async fn test_field_validation_default_pod_unknown_field_rejected_k8s_1_35() {
     let (_mem, router) = spawn_router();
     let mut stub = pod_stub("pod-default-strict");

--- a/crates/api-server/tests/decoder_strict_fields_test.rs
+++ b/crates/api-server/tests/decoder_strict_fields_test.rs
@@ -1,0 +1,624 @@
+//! Strict JSON decoder tests for `?fieldValidation=<mode>`.
+//!
+//! Mirrors upstream Kubernetes apimachinery serializer/json strict-decoding
+//! tests. The wire contract is:
+//!
+//! - `fieldValidation=Strict`  → reject unknown / duplicate JSON fields with
+//!   an HTTP error whose body is a `Status` object identifying the offending
+//!   field paths. Upstream serializes as `strict decoding error: ...`.
+//! - `fieldValidation=Warn`    → accept the request, drop unknown fields on
+//!   read-back, and emit one `Warning:` header per unknown field.
+//! - `fieldValidation=Ignore`  → accept silently; unknown fields are dropped
+//!   on read-back with no header.
+//! - No param                  → in Kubernetes >= 1.25 the server-side
+//!   default is `Strict`. Rusternetes currently defaults to `Ignore`
+//!   (handler short-circuits when the query param is absent), so the
+//!   strict-default test is `#[ignore]` pending parity work.
+//!
+//! Pattern follows `tests/integration_dryrun_all_resources.rs` — spawn an
+//! in-process Axum router backed by `MemoryStorage`, drive it with
+//! `tower::ServiceExt::oneshot`, and inspect the response.
+//!
+//! Tests are named `test_field_validation_<mode>_<scenario>` per the unit
+//! brief.
+
+use axum::{
+    body::Body,
+    http::{Method, Request, StatusCode},
+    Router,
+};
+use rusternetes_api_server::{router::build_router, state::ApiServerState};
+use rusternetes_common::{
+    auth::TokenManager, authz::AlwaysAllowAuthorizer, observability::MetricsRegistry,
+};
+use rusternetes_storage::{memory::MemoryStorage, StorageBackend};
+use serde_json::{json, Value};
+use std::sync::Arc;
+use tower::ServiceExt;
+
+// ---------------------------------------------------------------------------
+// HTTP harness — mirrors `integration_dryrun_all_resources.rs:82-100`.
+// ---------------------------------------------------------------------------
+
+const TEST_NS: &str = "fieldvalidation";
+
+fn make_state(mem: Arc<MemoryStorage>) -> Arc<ApiServerState> {
+    let backend = Arc::new(StorageBackend::Memory(mem));
+    let token_manager = Arc::new(TokenManager::new(b"test-secret"));
+    let authorizer = Arc::new(AlwaysAllowAuthorizer);
+    let metrics = Arc::new(MetricsRegistry::new());
+    Arc::new(ApiServerState::new(
+        backend,
+        token_manager,
+        authorizer,
+        metrics,
+        true, // skip_auth
+    ))
+}
+
+fn spawn_router() -> (Arc<MemoryStorage>, Router) {
+    let mem = Arc::new(MemoryStorage::new());
+    let router = build_router(make_state(mem.clone()), None);
+    (mem, router)
+}
+
+/// Send a raw JSON byte body so we can exercise duplicate keys that would
+/// otherwise be normalized away by `serde_json::to_vec`.
+async fn send_raw(
+    router: Router,
+    method: Method,
+    uri: &str,
+    body: Vec<u8>,
+) -> (StatusCode, Vec<(String, String)>, Value) {
+    let req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let response = router.oneshot(req).await.unwrap();
+    let status = response.status();
+    let headers: Vec<(String, String)> = response
+        .headers()
+        .iter()
+        .map(|(k, v)| {
+            (
+                k.as_str().to_string(),
+                v.to_str().unwrap_or_default().to_string(),
+            )
+        })
+        .collect();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let v: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, headers, v)
+}
+
+async fn send_json(
+    router: Router,
+    method: Method,
+    uri: &str,
+    body: &Value,
+) -> (StatusCode, Vec<(String, String)>, Value) {
+    let bytes = serde_json::to_vec(body).unwrap();
+    send_raw(router, method, uri, bytes).await
+}
+
+fn warning_headers(headers: &[(String, String)]) -> Vec<&str> {
+    headers
+        .iter()
+        .filter(|(k, _)| k.eq_ignore_ascii_case("warning"))
+        .map(|(_, v)| v.as_str())
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Resource stubs — minimal valid bodies for each representative GVR.
+// ---------------------------------------------------------------------------
+
+fn pod_uri() -> String {
+    format!("/api/v1/namespaces/{}/pods", TEST_NS)
+}
+
+fn pod_stub(name: &str) -> Value {
+    json!({
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {"name": name, "namespace": TEST_NS},
+        "spec": {"containers": [{"name": "c1", "image": "busybox"}]}
+    })
+}
+
+fn deployment_uri() -> String {
+    format!("/apis/apps/v1/namespaces/{}/deployments", TEST_NS)
+}
+
+fn deployment_stub(name: &str) -> Value {
+    json!({
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {"name": name, "namespace": TEST_NS},
+        "spec": {
+            "selector": {"matchLabels": {"app": "x"}},
+            "template": {
+                "metadata": {"labels": {"app": "x"}},
+                "spec": {"containers": [{"image": "busybox", "name": "c"}]}
+            }
+        }
+    })
+}
+
+fn service_uri() -> String {
+    format!("/api/v1/namespaces/{}/services", TEST_NS)
+}
+
+fn service_stub(name: &str) -> Value {
+    json!({
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {"name": name, "namespace": TEST_NS},
+        "spec": {
+            "type": "ClusterIP",
+            "ports": [{"port": 80, "targetPort": 8080}],
+            "selector": {"app": "x"}
+        }
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Strict mode — unknown fields
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_field_validation_strict_pod_unknown_field_rejected() {
+    let (_mem, router) = spawn_router();
+    let mut stub = pod_stub("pod-strict-unknown");
+    stub["spec"]["bogusField"] = json!("nope");
+    let uri = format!("{}?fieldValidation=Strict", pod_uri());
+
+    let (status, _hdrs, body) = send_json(router, Method::POST, &uri, &stub).await;
+
+    // Rusternetes maps strict-decoding errors through `Error::InvalidResource`,
+    // which renders as HTTP 422 with a Kubernetes `Status` body whose reason
+    // is `Invalid` (see crates/common/src/error.rs:105). Upstream uses 400 /
+    // `BadRequest`; the parity gap is tracked by the ignored test below.
+    assert!(
+        status.is_client_error(),
+        "expected 4xx for strict unknown field, got {}: body={}",
+        status,
+        body
+    );
+    assert_eq!(body["kind"], "Status", "body should be a Status object");
+    assert_eq!(body["status"], "Failure");
+    let message = body["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("strict decoding error"),
+        "message should mention strict decoding error: {}",
+        message
+    );
+    assert!(
+        message.contains("bogusField"),
+        "message should identify the offending field: {}",
+        message
+    );
+}
+
+#[tokio::test]
+async fn test_field_validation_strict_deployment_unknown_field_rejected() {
+    let (_mem, router) = spawn_router();
+    let mut stub = deployment_stub("dep-strict-unknown");
+    stub["spec"]["weirdoFlag"] = json!(true);
+    let uri = format!("{}?fieldValidation=Strict", deployment_uri());
+
+    let (status, _hdrs, body) = send_json(router, Method::POST, &uri, &stub).await;
+
+    assert!(
+        status.is_client_error(),
+        "expected 4xx for strict unknown field on Deployment, got {}: body={}",
+        status,
+        body
+    );
+    assert_eq!(body["kind"], "Status");
+    let message = body["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("strict decoding error") && message.contains("weirdoFlag"),
+        "message should call out unknown field 'weirdoFlag': {}",
+        message
+    );
+}
+
+#[tokio::test]
+#[ignore = "blocked on issue #TBD: Service handler does not call validate_strict_fields; \
+            unknown fields are silently dropped instead of rejected"]
+async fn test_field_validation_strict_service_unknown_field_rejected() {
+    let (_mem, router) = spawn_router();
+    let mut stub = service_stub("svc-strict-unknown");
+    stub["spec"]["unsupportedThing"] = json!(42);
+    let uri = format!("{}?fieldValidation=Strict", service_uri());
+
+    let (status, _hdrs, body) = send_json(router, Method::POST, &uri, &stub).await;
+
+    assert!(
+        status.is_client_error(),
+        "expected 4xx for strict unknown field on Service, got {}: body={}",
+        status,
+        body
+    );
+    assert_eq!(body["kind"], "Status");
+    let message = body["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("strict decoding error") && message.contains("unsupportedThing"),
+        "message should call out the unknown field: {}",
+        message
+    );
+}
+
+#[tokio::test]
+async fn test_field_validation_strict_pod_duplicate_field_rejected() {
+    let (_mem, router) = spawn_router();
+    // Pod with duplicate `metadata.namespace` keys. We assemble the JSON by
+    // hand because `serde_json::Value` deduplicates keys at parse time.
+    let body = format!(
+        r#"{{
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {{"name": "pod-strict-dup", "namespace": "{ns}", "namespace": "{ns}"}},
+            "spec": {{"containers": [{{"name": "c1", "image": "busybox"}}]}}
+        }}"#,
+        ns = TEST_NS
+    );
+    let uri = format!("{}?fieldValidation=Strict", pod_uri());
+
+    let (status, _hdrs, resp) = send_raw(router, Method::POST, &uri, body.into_bytes()).await;
+
+    assert!(
+        status.is_client_error(),
+        "expected 4xx for strict duplicate field, got {}: body={}",
+        status,
+        resp
+    );
+    assert_eq!(resp["kind"], "Status");
+    let message = resp["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("duplicate field") || message.contains("strict decoding error"),
+        "message should mention duplicate field: {}",
+        message
+    );
+    assert!(
+        message.contains("namespace"),
+        "message should identify the duplicated field 'namespace': {}",
+        message
+    );
+}
+
+#[tokio::test]
+async fn test_field_validation_strict_deployment_duplicate_field_rejected() {
+    let (_mem, router) = spawn_router();
+    // Duplicate `spec.replicas` keys — known parity case from
+    // crates/api-server/src/handlers/deployment.rs:36.
+    let body = format!(
+        r#"{{
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {{"name": "dep-strict-dup", "namespace": "{ns}"}},
+            "spec": {{
+                "replicas": 1,
+                "replicas": 2,
+                "selector": {{"matchLabels": {{"app": "x"}}}},
+                "template": {{
+                    "metadata": {{"labels": {{"app": "x"}}}},
+                    "spec": {{"containers": [{{"image": "busybox", "name": "c"}}]}}
+                }}
+            }}
+        }}"#,
+        ns = TEST_NS
+    );
+    let uri = format!("{}?fieldValidation=Strict", deployment_uri());
+
+    let (status, _hdrs, resp) = send_raw(router, Method::POST, &uri, body.into_bytes()).await;
+
+    assert!(
+        status.is_client_error(),
+        "expected 4xx for strict duplicate spec.replicas, got {}: body={}",
+        status,
+        resp
+    );
+    assert_eq!(resp["kind"], "Status");
+    let message = resp["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("duplicate field"),
+        "message should mention duplicate field: {}",
+        message
+    );
+    assert!(
+        message.contains("spec.replicas") || message.contains("replicas"),
+        "message should identify duplicated 'spec.replicas' path: {}",
+        message
+    );
+}
+
+#[tokio::test]
+async fn test_field_validation_strict_status_body_reason_invalid() {
+    // Upstream returns a Status object with reason = "BadRequest" (HTTP 400).
+    // Rusternetes routes strict-decode errors through `Error::InvalidResource`
+    // which produces reason = "Invalid" (HTTP 422). Pin the *actual* contract
+    // so any future change is intentional — and document the upstream-parity
+    // gap explicitly inline.
+    let (_mem, router) = spawn_router();
+    let mut stub = pod_stub("pod-status-shape");
+    stub["spec"]["bogus"] = json!("x");
+    let uri = format!("{}?fieldValidation=Strict", pod_uri());
+
+    let (status, _hdrs, body) = send_json(router, Method::POST, &uri, &stub).await;
+
+    assert_eq!(
+        status,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "rusternetes currently returns 422 for strict decode failures"
+    );
+    assert_eq!(body["kind"], "Status");
+    assert_eq!(body["apiVersion"], "v1");
+    assert_eq!(body["status"], "Failure");
+    assert_eq!(
+        body["reason"], "Invalid",
+        "rusternetes uses reason=Invalid; upstream uses BadRequest (issue #TBD)"
+    );
+    assert_eq!(body["code"], 422);
+}
+
+#[tokio::test]
+#[ignore = "blocked on issue #TBD: rusternetes returns HTTP 422 reason=Invalid for strict \
+            decode failures; upstream k8s 1.35 returns HTTP 400 reason=BadRequest"]
+async fn test_field_validation_strict_returns_400_badrequest_upstream_parity() {
+    let (_mem, router) = spawn_router();
+    let mut stub = pod_stub("pod-upstream-parity");
+    stub["spec"]["bogus"] = json!("x");
+    let uri = format!("{}?fieldValidation=Strict", pod_uri());
+
+    let (status, _hdrs, body) = send_json(router, Method::POST, &uri, &stub).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body["reason"], "BadRequest");
+    assert_eq!(body["code"], 400);
+}
+
+// ---------------------------------------------------------------------------
+// Warn mode
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_field_validation_warn_pod_unknown_field_accepted() {
+    // Warn mode must accept the request and persist the resource.
+    let (_mem, router) = spawn_router();
+    let mut stub = pod_stub("pod-warn-unknown");
+    stub["spec"]["bogusField"] = json!("ignored");
+    let uri = format!("{}?fieldValidation=Warn", pod_uri());
+
+    let (status, _hdrs, body) = send_json(router, Method::POST, &uri, &stub).await;
+
+    assert!(
+        status.is_success(),
+        "Warn mode must accept unknown fields; got {}: body={}",
+        status,
+        body
+    );
+    assert_eq!(body["kind"], "Pod");
+    assert_eq!(body["metadata"]["name"], "pod-warn-unknown");
+    // Unknown field is dropped on read-back — strongly typed Pod has no slot
+    // for `bogusField`, so it must not round-trip.
+    assert!(
+        body["spec"].get("bogusField").is_none(),
+        "unknown field must be dropped from the response body: {}",
+        body["spec"]
+    );
+}
+
+#[tokio::test]
+#[ignore = "blocked on issue #TBD: Warn mode does not emit Warning: 299 headers \
+            (validate_strict_fields short-circuits for non-Strict modes)"]
+async fn test_field_validation_warn_pod_emits_warning_header() {
+    let (_mem, router) = spawn_router();
+    let mut stub = pod_stub("pod-warn-header");
+    stub["spec"]["bogusField"] = json!("ignored");
+    let uri = format!("{}?fieldValidation=Warn", pod_uri());
+
+    let (status, headers, _body) = send_json(router, Method::POST, &uri, &stub).await;
+
+    assert!(status.is_success(), "Warn mode should succeed");
+    let warnings = warning_headers(&headers);
+    assert!(
+        !warnings.is_empty(),
+        "Warn mode must emit at least one Warning header"
+    );
+    assert!(
+        warnings.iter().any(|w| w.contains("bogusField")),
+        "Warning header must mention the unknown field: {:?}",
+        warnings
+    );
+    // Upstream prefixes warnings with `299 - "..."`; record that pattern here.
+    assert!(
+        warnings.iter().any(|w| w.starts_with("299 ")),
+        "Warning headers should use code 299 per RFC 7234: {:?}",
+        warnings
+    );
+}
+
+#[tokio::test]
+async fn test_field_validation_warn_deployment_unknown_field_accepted() {
+    let (_mem, router) = spawn_router();
+    let mut stub = deployment_stub("dep-warn");
+    stub["spec"]["weirdFlag"] = json!(true);
+    let uri = format!("{}?fieldValidation=Warn", deployment_uri());
+
+    let (status, _hdrs, body) = send_json(router, Method::POST, &uri, &stub).await;
+
+    assert!(
+        status.is_success(),
+        "Warn mode should accept unknown field on Deployment; got {}: body={}",
+        status,
+        body
+    );
+    assert!(
+        body["spec"].get("weirdFlag").is_none(),
+        "unknown field must be stripped from the response: {}",
+        body["spec"]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Ignore mode
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_field_validation_ignore_pod_unknown_field_silently_accepted() {
+    let (_mem, router) = spawn_router();
+    let mut stub = pod_stub("pod-ignore");
+    stub["spec"]["bogusField"] = json!("dropped");
+    let uri = format!("{}?fieldValidation=Ignore", pod_uri());
+
+    let (status, headers, body) = send_json(router, Method::POST, &uri, &stub).await;
+
+    assert!(
+        status.is_success(),
+        "Ignore mode must accept the request; got {}: body={}",
+        status,
+        body
+    );
+    let warnings = warning_headers(&headers);
+    assert!(
+        warnings.is_empty(),
+        "Ignore mode must not emit Warning headers, got {:?}",
+        warnings
+    );
+    assert!(
+        body["spec"].get("bogusField").is_none(),
+        "unknown field must be dropped on read-back: {}",
+        body["spec"]
+    );
+}
+
+#[tokio::test]
+async fn test_field_validation_ignore_deployment_unknown_field_silently_accepted() {
+    let (_mem, router) = spawn_router();
+    let mut stub = deployment_stub("dep-ignore");
+    stub["spec"]["weirdFlag"] = json!(true);
+    let uri = format!("{}?fieldValidation=Ignore", deployment_uri());
+
+    let (status, headers, body) = send_json(router, Method::POST, &uri, &stub).await;
+
+    assert!(
+        status.is_success(),
+        "Ignore mode should succeed on Deployment; got {}: body={}",
+        status,
+        body
+    );
+    let warnings = warning_headers(&headers);
+    assert!(
+        warnings.is_empty(),
+        "Ignore mode must not emit Warning headers, got {:?}",
+        warnings
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Default mode (no `fieldValidation=` query param)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_field_validation_default_pod_unknown_field_currently_accepted() {
+    // Pin rusternetes's *current* default behaviour: with no fieldValidation
+    // query param, the validator short-circuits at validation.rs:378-380 and
+    // unknown fields are silently dropped. This matches kubectl pre-1.25 and
+    // upstream's `Ignore` mode, NOT the modern server-side default of Strict.
+    let (_mem, router) = spawn_router();
+    let mut stub = pod_stub("pod-default");
+    stub["spec"]["bogusField"] = json!("nope");
+    let uri = pod_uri();
+
+    let (status, _hdrs, body) = send_json(router, Method::POST, &uri, &stub).await;
+
+    assert!(
+        status.is_success(),
+        "current default is non-strict; expected 2xx, got {}: body={}",
+        status,
+        body
+    );
+    assert!(
+        body["spec"].get("bogusField").is_none(),
+        "unknown field is dropped: {}",
+        body["spec"]
+    );
+}
+
+#[tokio::test]
+#[ignore = "blocked on issue #TBD: default fieldValidation should be Strict per K8s 1.35; \
+            rusternetes currently defaults to Ignore (validate_strict_fields short-circuits \
+            on missing param)"]
+async fn test_field_validation_default_pod_unknown_field_rejected_k8s_1_35() {
+    let (_mem, router) = spawn_router();
+    let mut stub = pod_stub("pod-default-strict");
+    stub["spec"]["bogusField"] = json!("nope");
+    let uri = pod_uri();
+
+    let (status, _hdrs, body) = send_json(router, Method::POST, &uri, &stub).await;
+
+    assert!(
+        status.is_client_error(),
+        "K8s 1.35 default must reject unknown fields without explicit param; \
+         got {}: body={}",
+        status,
+        body
+    );
+    let message = body["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("strict decoding error"),
+        "default rejection should match strict decoder format: {}",
+        message
+    );
+}
+
+// ---------------------------------------------------------------------------
+// PUT (update) path — strict mode should fire on updates too.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "blocked on issue #TBD: pod update handler does not call validate_strict_fields \
+            (see crates/api-server/src/handlers/pod.rs:642 — no strict check on PUT path)"]
+async fn test_field_validation_strict_pod_update_unknown_field_rejected() {
+    let (_mem, router) = spawn_router();
+
+    // Seed a pod first so PUT has something to update.
+    let stub = pod_stub("pod-update-strict");
+    let (create_status, _, create_body) =
+        send_json(router.clone(), Method::POST, &pod_uri(), &stub).await;
+    assert!(
+        create_status.is_success(),
+        "seed pod create should succeed, got {}: {}",
+        create_status,
+        create_body
+    );
+
+    // Now PUT with an unknown field + fieldValidation=Strict.
+    let mut updated = stub.clone();
+    updated["spec"]["bogusField"] = json!("nope");
+    let put_uri = format!(
+        "/api/v1/namespaces/{}/pods/pod-update-strict?fieldValidation=Strict",
+        TEST_NS
+    );
+    let (status, _hdrs, body) = send_json(router, Method::PUT, &put_uri, &updated).await;
+
+    assert!(
+        status.is_client_error(),
+        "PUT with fieldValidation=Strict must reject unknown fields, got {}: {}",
+        status,
+        body
+    );
+    assert_eq!(body["kind"], "Status");
+    let message = body["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("strict decoding error") && message.contains("bogusField"),
+        "update strict error should identify field: {}",
+        message
+    );
+}

--- a/crates/api-server/tests/patch_cas_retry_test.rs
+++ b/crates/api-server/tests/patch_cas_retry_test.rs
@@ -1,0 +1,196 @@
+//! Regression tests for PATCH retry on resourceVersion conflict.
+//!
+//! Covers:
+//!   8f271ca  fix: PATCH retry on rv conflict + inline ObjectMeta
+//!             → generic_patch.rs: retry once on Error::Conflict from storage.update()
+//!   4f9111b  fix: scale PATCH retry on resourceVersion conflict
+//!             → scale.rs: retry up to 5 times on Error::Conflict from storage.update()
+//!
+//! Each test spins up a full `ApiServerState` backed by `StorageBackend::Memory`
+//! (pointing to an `Arc<MemoryStorage>` with conflict injection), builds the
+//! Axum router, and sends a real HTTP PATCH request through tower's `oneshot`.
+//! The `MemoryStorage::inject_conflicts(1)` call primes the storage to return
+//! `Error::Conflict` on the *first* `update()` call, simulating the etcd CAS
+//! mismatch that triggered these fixes.
+//!
+//! Revert scenario: reverting the retry loop causes the Conflict to be surfaced
+//! to the client as HTTP 409 instead of the expected 200.
+
+use axum::{body::Body, http::Request};
+use rusternetes_api_server::{router::build_router, state::ApiServerState};
+use rusternetes_common::auth::TokenManager;
+use rusternetes_common::authz::AlwaysAllowAuthorizer;
+use rusternetes_common::observability::MetricsRegistry;
+use rusternetes_storage::{build_key, memory::MemoryStorage, Storage, StorageBackend};
+use serde_json::{json, Value};
+use std::sync::Arc;
+use tower::ServiceExt;
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/// Construct a minimal `ApiServerState` backed by the given `MemoryStorage`.
+/// `skip_auth = true` so the router uses `skip_auth_middleware` and no token
+/// is needed.
+fn make_state(mem: Arc<MemoryStorage>) -> Arc<ApiServerState> {
+    let backend = Arc::new(StorageBackend::Memory(mem));
+    let token_manager = Arc::new(TokenManager::new(b"test-secret"));
+    let authorizer = Arc::new(AlwaysAllowAuthorizer);
+    let metrics = Arc::new(MetricsRegistry::new());
+    Arc::new(ApiServerState::new(
+        backend,
+        token_manager,
+        authorizer,
+        metrics,
+        true, // skip_auth
+    ))
+}
+
+/// Send a PATCH request to `uri` with the given JSON body and
+/// `Content-Type: application/merge-patch+json`.
+/// Returns the HTTP status code and the response body as a `serde_json::Value`.
+async fn patch_json(state: Arc<ApiServerState>, uri: &str, body: &Value) -> (u16, Value) {
+    let router = build_router(state, None);
+    let body_bytes = serde_json::to_vec(body).unwrap();
+    let req = Request::builder()
+        .method("PATCH")
+        .uri(uri)
+        .header("content-type", "application/merge-patch+json")
+        .body(Body::from(body_bytes))
+        .unwrap();
+    let response = router.oneshot(req).await.unwrap();
+    let status = response.status().as_u16();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body_json: Value = serde_json::from_slice(&body_bytes).unwrap_or(json!(null));
+    (status, body_json)
+}
+
+// ---------------------------------------------------------------------------
+// 8f271ca  — generic PATCH retry
+// ---------------------------------------------------------------------------
+
+/// Regression test for commit 8f271ca.
+///
+/// The fix adds a retry branch in `patch_namespaced_resource`: when
+/// `storage.update()` returns `Error::Conflict`, re-read the resource, re-apply
+/// the patch, and try again.
+///
+/// Without the fix, the first `Conflict` would be propagated to the client as
+/// HTTP 409. With the fix, the handler retries and returns HTTP 200 with the
+/// patched resource.
+#[tokio::test]
+async fn test_patch_generic_retries_on_conflict() {
+    let mem = Arc::new(MemoryStorage::new());
+
+    // Pre-create a ConfigMap so the handler finds it.
+    let cm = json!({
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {
+            "name": "cm-retry-test",
+            "namespace": "default"
+        },
+        "data": {
+            "key": "original"
+        }
+    });
+    let key = build_key("configmaps", Some("default"), "cm-retry-test");
+    mem.create(&key, &cm).await.unwrap();
+
+    // Arm the conflict injector: the NEXT update() call returns Error::Conflict.
+    mem.inject_conflicts(1);
+
+    let state = make_state(mem.clone());
+    let patch = json!({"data": {"key": "patched"}});
+    let (status, body) = patch_json(
+        state,
+        "/api/v1/namespaces/default/configmaps/cm-retry-test",
+        &patch,
+    )
+    .await;
+
+    println!("status={} body={}", status, body);
+
+    assert_eq!(
+        status, 200,
+        "PATCH must succeed (200) even when the first update() returns Conflict; \
+         got {} — did the retry loop get reverted? body={}",
+        status, body
+    );
+    assert_eq!(
+        body["data"]["key"], "patched",
+        "Patch must be applied in the retried write"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4f9111b  — scale PATCH retry
+// ---------------------------------------------------------------------------
+
+/// Regression test for the scale-PATCH sub-fix in commit 4f9111b.
+///
+/// The fix wraps the `get + update` loop in `patch_scale` with a retry: on
+/// `Error::Conflict`, re-read the resource and retry the write.
+///
+/// Without the fix, the first `Conflict` is returned to the client as HTTP 409.
+/// With the fix, the handler retries and returns HTTP 200 with the patched scale.
+#[tokio::test]
+async fn test_patch_scale_retries_on_conflict() {
+    let mem = Arc::new(MemoryStorage::new());
+
+    // Pre-create a Deployment so patch_scale can find it.
+    let deployment = json!({
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+            "name": "scale-retry-deploy",
+            "namespace": "default"
+        },
+        "spec": {
+            "replicas": 2,
+            "selector": {
+                "matchLabels": {"app": "scale-retry"}
+            },
+            "template": {
+                "metadata": {"labels": {"app": "scale-retry"}},
+                "spec": {
+                    "containers": [{"name": "app", "image": "nginx:latest"}]
+                }
+            }
+        },
+        "status": {
+            "replicas": 2
+        }
+    });
+    let key = build_key("deployments", Some("default"), "scale-retry-deploy");
+    mem.create(&key, &deployment).await.unwrap();
+
+    // Arm the conflict injector.
+    mem.inject_conflicts(1);
+
+    let state = make_state(mem.clone());
+    // K8s scale PATCH body: {"spec":{"replicas": N}}
+    let patch = json!({"spec": {"replicas": 5}});
+    let (status, body) = patch_json(
+        state,
+        "/apis/apps/v1/namespaces/default/deployments/scale-retry-deploy/scale",
+        &patch,
+    )
+    .await;
+
+    println!("status={} body={}", status, body);
+
+    assert_eq!(
+        status, 200,
+        "Scale PATCH must succeed (200) even when the first update() returns Conflict; \
+         got {} — did the retry loop in patch_scale get reverted? body={}",
+        status, body
+    );
+    assert_eq!(
+        body["spec"]["replicas"], 5,
+        "Replicas must reflect the patched value"
+    );
+}

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -11,6 +11,15 @@ pub enum Error {
     #[error("Invalid resource: {0}")]
     InvalidResource(String),
 
+    /// Generic bad-request error mapped to HTTP 400 / reason=BadRequest.
+    ///
+    /// Upstream Kubernetes uses 400/BadRequest for strict-decode errors and
+    /// other "client supplied a syntactically malformed request" cases. Use
+    /// `InvalidResource` instead when the request parses cleanly but fails a
+    /// field-level validator (that maps to 422/Invalid).
+    #[error("Bad request: {0}")]
+    BadRequest(String),
+
     #[error("Serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
 
@@ -55,6 +64,7 @@ impl Error {
             Error::NotFound(_) => "NotFound",
             Error::AlreadyExists(_) => "AlreadyExists",
             Error::InvalidResource(_) => "Invalid",
+            Error::BadRequest(_) => "BadRequest",
             Error::Serialization(_) => "BadRequest",
             Error::Storage(_) => "InternalError",
             Error::Network(_) => "ServiceUnavailable",
@@ -106,6 +116,11 @@ impl axum::response::IntoResponse for Error {
                 let details = extract_resource_details_for_invalid(&msg);
                 (StatusCode::UNPROCESSABLE_ENTITY, msg, "Invalid", details)
             }
+            // Mirrors upstream k8s apimachinery/pkg/api/errors/errors.go:
+            // strict decoding errors and other syntactic / client-malformed
+            // requests return HTTP 400 with reason=BadRequest (NOT 422/Invalid,
+            // which is reserved for semantic field-validation errors).
+            Error::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg, "BadRequest", None),
             Error::Authentication(msg) => (StatusCode::UNAUTHORIZED, msg, "Unauthorized", None),
             Error::Authorization(msg) => (StatusCode::FORBIDDEN, msg, "Forbidden", None),
             Error::Forbidden(msg) => (StatusCode::FORBIDDEN, msg, "Forbidden", None),

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use rusternetes_common::authz::AuthzStorage;
 use rusternetes_common::Result;
 use serde::{de::DeserializeOwned, Serialize};
+use std::sync::Arc;
 
 pub mod concurrency;
 pub mod etcd;
@@ -152,7 +153,7 @@ pub enum StorageConfig {
     },
 }
 
-/// Unified storage backend that dispatches to etcd, SQLite, or Redis at runtime.
+/// Unified storage backend that dispatches to etcd, SQLite, Redis, or in-memory at runtime.
 ///
 /// This allows all components to remain generic over `S: Storage` while the
 /// concrete backend is chosen once at startup via `StorageConfig`.
@@ -163,6 +164,9 @@ pub enum StorageBackend {
     Sqlite(RhinoStorage),
     #[cfg(feature = "redis")]
     Redis(RhinoRedisStorage),
+    /// In-memory backend backed by `MemoryStorage`. Intended for unit/integration
+    /// tests that need a full `ApiServerState` without an external store.
+    Memory(Arc<MemoryStorage>),
 }
 
 impl StorageBackend {
@@ -185,6 +189,14 @@ impl StorageBackend {
             }
         }
     }
+
+    /// Construct an in-memory backend suitable for unit/integration tests.
+    /// Wraps `MemoryStorage` in an `Arc` so the same handle can be cloned by
+    /// the caller (e.g. for `inject_conflicts(...)`) while the enum owns one
+    /// copy.
+    pub fn new_memory() -> Self {
+        StorageBackend::Memory(Arc::new(MemoryStorage::new()))
+    }
 }
 
 #[async_trait]
@@ -199,6 +211,7 @@ impl Storage for StorageBackend {
             StorageBackend::Sqlite(s) => Storage::create(s, key, value).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => Storage::create(s, key, value).await,
+            StorageBackend::Memory(s) => Storage::create(s.as_ref(), key, value).await,
         }
     }
 
@@ -212,6 +225,7 @@ impl Storage for StorageBackend {
             StorageBackend::Sqlite(s) => Storage::get(s, key).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => Storage::get(s, key).await,
+            StorageBackend::Memory(s) => Storage::get(s.as_ref(), key).await,
         }
     }
 
@@ -225,6 +239,7 @@ impl Storage for StorageBackend {
             StorageBackend::Sqlite(s) => Storage::update(s, key, value).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => Storage::update(s, key, value).await,
+            StorageBackend::Memory(s) => Storage::update(s.as_ref(), key, value).await,
         }
     }
 
@@ -235,6 +250,7 @@ impl Storage for StorageBackend {
             StorageBackend::Sqlite(s) => Storage::update_raw(s, key, value).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => Storage::update_raw(s, key, value).await,
+            StorageBackend::Memory(s) => Storage::update_raw(s.as_ref(), key, value).await,
         }
     }
 
@@ -245,6 +261,7 @@ impl Storage for StorageBackend {
             StorageBackend::Sqlite(s) => Storage::delete(s, key).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => Storage::delete(s, key).await,
+            StorageBackend::Memory(s) => Storage::delete(s.as_ref(), key).await,
         }
     }
 
@@ -258,6 +275,7 @@ impl Storage for StorageBackend {
             StorageBackend::Sqlite(s) => Storage::list(s, prefix).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => Storage::list(s, prefix).await,
+            StorageBackend::Memory(s) => Storage::list(s.as_ref(), prefix).await,
         }
     }
 
@@ -268,6 +286,7 @@ impl Storage for StorageBackend {
             StorageBackend::Sqlite(s) => Storage::watch(s, prefix).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => Storage::watch(s, prefix).await,
+            StorageBackend::Memory(s) => Storage::watch(s.as_ref(), prefix).await,
         }
     }
 
@@ -278,6 +297,9 @@ impl Storage for StorageBackend {
             StorageBackend::Sqlite(s) => Storage::watch_from_revision(s, prefix, revision).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => Storage::watch_from_revision(s, prefix, revision).await,
+            StorageBackend::Memory(s) => {
+                Storage::watch_from_revision(s.as_ref(), prefix, revision).await
+            }
         }
     }
 
@@ -288,6 +310,7 @@ impl Storage for StorageBackend {
             StorageBackend::Sqlite(s) => Storage::current_revision(s).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => Storage::current_revision(s).await,
+            StorageBackend::Memory(s) => Storage::current_revision(s.as_ref()).await,
         }
     }
 
@@ -298,6 +321,7 @@ impl Storage for StorageBackend {
             StorageBackend::Sqlite(s) => Storage::is_revision_compacted(s, revision).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => Storage::is_revision_compacted(s, revision).await,
+            StorageBackend::Memory(s) => Storage::is_revision_compacted(s.as_ref(), revision).await,
         }
     }
 }
@@ -315,6 +339,7 @@ impl rusternetes_common::authz::AuthzStorage for StorageBackend {
             StorageBackend::Sqlite(s) => AuthzStorage::get(s, key, namespace).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => AuthzStorage::get(s, key, namespace).await,
+            StorageBackend::Memory(s) => AuthzStorage::get(s.as_ref(), key, namespace).await,
         }
     }
 
@@ -328,6 +353,7 @@ impl rusternetes_common::authz::AuthzStorage for StorageBackend {
             StorageBackend::Sqlite(s) => AuthzStorage::list(s, namespace).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => AuthzStorage::list(s, namespace).await,
+            StorageBackend::Memory(s) => AuthzStorage::list(s.as_ref(), namespace).await,
         }
     }
 }

--- a/crates/storage/src/memory.rs
+++ b/crates/storage/src/memory.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 use rusternetes_common::{Error, Result};
 use serde::{de::DeserializeOwned, Serialize};
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 use tokio::sync::broadcast;
 
@@ -12,6 +13,9 @@ pub struct MemoryStorage {
     data: Arc<RwLock<HashMap<String, String>>>,
     // Broadcast channel for watch events
     watch_tx: broadcast::Sender<WatchEvent>,
+    /// Number of remaining update() calls that will return Error::Conflict
+    /// before delegating to the real update. Used by tests to inject CAS conflicts.
+    conflict_update_count: Arc<AtomicUsize>,
 }
 
 impl MemoryStorage {
@@ -21,6 +25,7 @@ impl MemoryStorage {
         Self {
             data: Arc::new(RwLock::new(HashMap::new())),
             watch_tx,
+            conflict_update_count: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -37,6 +42,12 @@ impl MemoryStorage {
     /// Check if storage is empty
     pub fn is_empty(&self) -> bool {
         self.data.read().unwrap().is_empty()
+    }
+
+    /// Arrange for the next `n` calls to `update()` to return `Error::Conflict`.
+    /// Subsequent calls behave normally. Used by tests to verify retry logic.
+    pub fn inject_conflicts(&self, n: usize) {
+        self.conflict_update_count.store(n, Ordering::SeqCst);
     }
 }
 
@@ -117,6 +128,22 @@ impl Storage for MemoryStorage {
     where
         T: Serialize + DeserializeOwned + Send + Sync,
     {
+        // Inject a Conflict error if requested by a test (see inject_conflicts).
+        if self.conflict_update_count.load(Ordering::SeqCst) > 0 {
+            let prev =
+                self.conflict_update_count
+                    .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| {
+                        if v > 0 {
+                            Some(v - 1)
+                        } else {
+                            None
+                        }
+                    });
+            if prev.is_ok() {
+                return Err(Error::Conflict("injected conflict for test".to_string()));
+            }
+        }
+
         let serialized = serde_json::to_string(value)?;
 
         let mut data = self.data.write().unwrap();
@@ -218,6 +245,72 @@ impl Storage for MemoryStorage {
 
     async fn is_revision_compacted(&self, _revision: i64) -> Result<bool> {
         Ok(false) // Memory storage never compacts
+    }
+}
+
+// AuthzStorage for MemoryStorage — used when StorageBackend::Memory is selected.
+// The RBAC queries in tests use AlwaysAllowAuthorizer so these methods are
+// typically not called; they're implemented for completeness.
+#[async_trait::async_trait]
+impl rusternetes_common::authz::AuthzStorage for MemoryStorage {
+    async fn get<T>(&self, key: &str, namespace: Option<&str>) -> rusternetes_common::Result<T>
+    where
+        T: serde::de::DeserializeOwned + Send + Sync,
+    {
+        use crate::build_key;
+        // Mirror the EtcdStorage pattern: derive a full /registry path from type name.
+        let full_key = match namespace {
+            Some(ns) => {
+                let tn = std::any::type_name::<T>();
+                if tn.contains("Role") && !tn.contains("Cluster") {
+                    format!("/registry/roles/{}/{}", ns, key)
+                } else if tn.contains("RoleBinding") && !tn.contains("Cluster") {
+                    format!("/registry/rolebindings/{}/{}", ns, key)
+                } else {
+                    build_key("unknown", Some(ns), key)
+                }
+            }
+            None => {
+                let tn = std::any::type_name::<T>();
+                if tn.contains("ClusterRole") && !tn.contains("Binding") {
+                    format!("/registry/clusterroles/{}", key)
+                } else if tn.contains("ClusterRoleBinding") {
+                    format!("/registry/clusterrolebindings/{}", key)
+                } else {
+                    format!("/registry/unknown/{}", key)
+                }
+            }
+        };
+        Storage::get(self, &full_key).await
+    }
+
+    async fn list<T>(&self, namespace: Option<&str>) -> rusternetes_common::Result<Vec<T>>
+    where
+        T: serde::Serialize + serde::de::DeserializeOwned + Send + Sync,
+    {
+        let prefix = match namespace {
+            Some(ns) => {
+                let tn = std::any::type_name::<T>();
+                if tn.contains("Role") && !tn.contains("Cluster") {
+                    format!("/registry/roles/{}/", ns)
+                } else if tn.contains("RoleBinding") && !tn.contains("Cluster") {
+                    format!("/registry/rolebindings/{}/", ns)
+                } else {
+                    format!("/registry/unknown/{}/", ns)
+                }
+            }
+            None => {
+                let tn = std::any::type_name::<T>();
+                if tn.contains("ClusterRole") && !tn.contains("Binding") {
+                    "/registry/clusterroles/".to_string()
+                } else if tn.contains("ClusterRoleBinding") {
+                    "/registry/clusterrolebindings/".to_string()
+                } else {
+                    "/registry/unknown/".to_string()
+                }
+            }
+        };
+        Storage::list(self, &prefix).await
     }
 }
 


### PR DESCRIPTION
## Summary

Bring \`?fieldValidation=\` decoding to client-go strict parity (k8s 1.35):

1. **Status code 400/BadRequest** on Strict-mode unknown fields (was 422/Invalid).
2. **\`Warning: 299 -\`** header emitted on Warn mode with one entry per unknown field.
3. **Default mode is Strict** when no \`?fieldValidation=\` query param is present (k8s 1.35 default; was Ignore).

Implementation lives in \`crates/api-server/src/handlers/validation.rs\`; status reason added to \`crates/common/src/error.rs\`; Pod create + Deployment apply paths wired in.

## Stacked on

Depends on #51 (StorageBackend::Memory variant) — needed by the test fixtures. If #51 lands first, GitHub will reduce this PR to just the validation + handler delta.

## Test plan

- [x] \`cargo test -p rusternetes-api-server --test decoder_strict_fields_test\` — 13/13 pass, 2 ignored
  - The 2 ignored tests pin remaining gaps: pod-update PUT path skips \`validate_strict_fields\`, Service handler skips it entirely. Tagged with \`#TBD\` for follow-up.
- [x] \`cargo fmt --all -- --check\` clean