### PR TITLE
fix(api-server): reject Pod create with spec:null + malformed-JSON tests

### DIFF
--- a/crates/api-server/src/handlers/pod.rs
+++ b/crates/api-server/src/handlers/pod.rs
@@ -60,6 +60,15 @@ pub async fn create(
     }
 
     // Validate pod spec
+    // K8s ref: pkg/apis/core/validation/validation.go ValidatePodSpec — `spec.containers`
+    // is required. Upstream uses `field.Required(field.NewPath("spec").Child("containers"), "")`
+    // when spec is missing/null. Reject `spec: null` (and an absent spec) with 422 Invalid
+    // here so we do not persist an empty Pod.
+    if pod.spec.is_none() {
+        return Err(rusternetes_common::Error::InvalidResource(
+            "spec.containers: Required value".to_string(),
+        ));
+    }
     if let Some(ref spec) = pod.spec {
         if spec.containers.is_empty() {
             return Err(rusternetes_common::Error::InvalidResource(

--- a/crates/api-server/tests/decoder_malformed_json_test.rs
+++ b/crates/api-server/tests/decoder_malformed_json_test.rs
@@ -195,7 +195,6 @@ async fn test_malformed_wrong_type_active_deadline() {
 // only validates containers when `spec` is `Some`. Result: 201 with an empty
 // Pod instead of 422 Invalid + Status.
 #[tokio::test]
-#[ignore = "blocked on issue #TBD: Pod create accepts `spec: null` and persists an empty Pod (201) instead of 422 Invalid — Pod.spec is Option<PodSpec> and the container check is gated on Some(spec)"]
 async fn test_malformed_spec_null() {
     let router = spawn_router();
     let body = br#"{"metadata":{"name":"p"},"spec":null}"#.to_vec();

--- a/crates/api-server/tests/decoder_malformed_json_test.rs
+++ b/crates/api-server/tests/decoder_malformed_json_test.rs
@@ -1,0 +1,260 @@
+//! Layer-4 decoder tests: malformed JSON request bodies must produce a valid
+//! Kubernetes `Status` failure response, NEVER plain text and NEVER an empty
+//! body.
+//!
+//! Upstream parity: `staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go`
+//! and the apiserver's `request.NegotiateInputSerializer` path reject malformed
+//! payloads at decode time and emit a Status object via `responsewriters.ErrorNegotiated`.
+//! The status code is typically `400 BadRequest` (decode error) or `422 Invalid`
+//! (semantic decode error such as wrong-type field on a known schema).
+//!
+//! rusternetes currently routes every body-decode failure through
+//! `Error::InvalidResource` (see `crates/api-server/src/handlers/pod.rs:31`),
+//! which maps to HTTP 422 with `reason=Invalid` in `crates/common/src/error.rs:105-108`.
+//! Either 400 or 422 is acceptable per upstream — the contract these tests pin
+//! is:
+//!   - response status is 4xx (one of {400, 422})
+//!   - response body parses as a Kubernetes `Status` object
+//!     (`kind=Status`, `apiVersion=v1`, `status=Failure`,
+//!     `reason ∈ {BadRequest, Invalid}`)
+//!   - response body is NOT empty and NOT plain text
+//!
+//! Each `test_malformed_<scenario>` POSTs a malformed body to
+//! `/api/v1/namespaces/default/pods` and asserts the contract above.
+
+use axum::{
+    body::Body,
+    http::{Method, Request},
+};
+use rusternetes_api_server::{router::build_router, state::ApiServerState};
+use rusternetes_common::{
+    auth::TokenManager, authz::AlwaysAllowAuthorizer, observability::MetricsRegistry,
+};
+use rusternetes_storage::{memory::MemoryStorage, StorageBackend};
+use serde_json::Value;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+// ---------------------------------------------------------------------------
+// HTTP harness — mirrors `integration_dryrun_all_resources.rs:82-100`.
+// ---------------------------------------------------------------------------
+
+fn make_state(mem: Arc<MemoryStorage>) -> Arc<ApiServerState> {
+    let backend = Arc::new(StorageBackend::Memory(mem));
+    let token_manager = Arc::new(TokenManager::new(b"test-secret"));
+    let authorizer = Arc::new(AlwaysAllowAuthorizer);
+    let metrics = Arc::new(MetricsRegistry::new());
+    Arc::new(ApiServerState::new(
+        backend,
+        token_manager,
+        authorizer,
+        metrics,
+        true, // skip_auth
+    ))
+}
+
+fn spawn_router() -> axum::Router {
+    let mem = Arc::new(MemoryStorage::new());
+    build_router(make_state(mem), None)
+}
+
+/// Send a raw byte body to the pod create endpoint and return
+/// `(status, body_bytes)`.
+async fn post_pod_raw(router: axum::Router, body: Vec<u8>) -> (u16, Vec<u8>) {
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/v1/namespaces/default/pods")
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let response = router.oneshot(req).await.unwrap();
+    let status = response.status().as_u16();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap()
+        .to_vec();
+    (status, bytes)
+}
+
+/// Assert the contract described in the file-level docs:
+///   - status is 400 or 422
+///   - body parses as a Kubernetes `Status` failure object
+///     (`kind=Status`, `apiVersion=v1`, `status=Failure`,
+///     `reason ∈ {BadRequest, Invalid}`)
+///   - body is non-empty
+fn assert_status_contract(scenario: &str, status: u16, body: &[u8]) {
+    assert!(
+        status == 400 || status == 422,
+        "[{}] expected HTTP 400 or 422 for malformed body, got {} body={:?}",
+        scenario,
+        status,
+        String::from_utf8_lossy(body),
+    );
+    assert!(
+        !body.is_empty(),
+        "[{}] response body must NOT be empty",
+        scenario,
+    );
+    let v: Value = serde_json::from_slice(body).unwrap_or_else(|e| {
+        panic!(
+            "[{}] response body must be valid JSON (a Status object), got {:?}: parse error {}",
+            scenario,
+            String::from_utf8_lossy(body),
+            e,
+        )
+    });
+    assert_eq!(
+        v["kind"], "Status",
+        "[{}] response must be a Status object, got body={}",
+        scenario, v
+    );
+    assert_eq!(
+        v["apiVersion"], "v1",
+        "[{}] Status.apiVersion must be v1, got body={}",
+        scenario, v
+    );
+    assert_eq!(
+        v["status"], "Failure",
+        "[{}] Status.status must be Failure, got body={}",
+        scenario, v
+    );
+    let reason = v["reason"].as_str().unwrap_or("");
+    assert!(
+        reason == "BadRequest" || reason == "Invalid",
+        "[{}] Status.reason must be BadRequest or Invalid, got {:?} body={}",
+        scenario,
+        reason,
+        v,
+    );
+}
+
+#[tokio::test]
+async fn test_malformed_empty_body() {
+    let router = spawn_router();
+    let (status, body) = post_pod_raw(router, Vec::new()).await;
+    assert_status_contract("empty_body", status, &body);
+}
+
+#[tokio::test]
+async fn test_malformed_truncated_open_brace() {
+    let router = spawn_router();
+    let (status, body) = post_pod_raw(router, b"{".to_vec()).await;
+    assert_status_contract("truncated_open_brace", status, &body);
+}
+
+#[tokio::test]
+async fn test_malformed_truncated_open_bracket() {
+    let router = spawn_router();
+    let (status, body) = post_pod_raw(router, b"[".to_vec()).await;
+    assert_status_contract("truncated_open_bracket", status, &body);
+}
+
+#[tokio::test]
+async fn test_malformed_truncated_key_only() {
+    let router = spawn_router();
+    let (status, body) = post_pod_raw(router, br#"{"kind":"#.to_vec()).await;
+    assert_status_contract("truncated_key_only", status, &body);
+}
+
+// `serde_json::from_slice` requires UTF-8 input; raw 0xff 0xfe inside a
+// string value is rejected at parse time.
+#[tokio::test]
+async fn test_malformed_invalid_utf8() {
+    let router = spawn_router();
+    let mut body = Vec::from(&b"{\"name\":\""[..]);
+    body.extend_from_slice(&[0xffu8, 0xfeu8]);
+    body.extend_from_slice(b"\"}");
+    let (status, body) = post_pod_raw(router, body).await;
+    assert_status_contract("invalid_utf8", status, &body);
+}
+
+// Closest Pod analogue to upstream's `Deployment{"spec":{"replicas":"three"}}`
+// case: top-level `metadata` is a non-Option field expecting an object.
+#[tokio::test]
+async fn test_malformed_wrong_type_metadata() {
+    let router = spawn_router();
+    let (status, body) = post_pod_raw(router, br#"{"metadata":"not-an-object"}"#.to_vec()).await;
+    assert_status_contract("wrong_type_metadata", status, &body);
+}
+
+// `spec.activeDeadlineSeconds` is `Option<i64>` in the schema; sending a
+// string forces a deserialization error.
+#[tokio::test]
+async fn test_malformed_wrong_type_active_deadline() {
+    let router = spawn_router();
+    let body = br#"{"metadata":{"name":"p"},"spec":{"activeDeadlineSeconds":"three","containers":[{"name":"c","image":"i"}]}}"#.to_vec();
+    let (status, body) = post_pod_raw(router, body).await;
+    assert_status_contract("wrong_type_active_deadline", status, &body);
+}
+
+// Upstream Kubernetes treats `spec` as required-non-nullable on PodTemplateSpec /
+// Pod: PodSpec validation ("spec.containers: Required value") fires when `spec`
+// is null/absent. In rusternetes, `Pod.spec` is `Option<PodSpec>`
+// (crates/common/src/resources/pod.rs:50), so `spec: null` deserializes to
+// `None` and the create handler at crates/api-server/src/handlers/pod.rs:63
+// only validates containers when `spec` is `Some`. Result: 201 with an empty
+// Pod instead of 422 Invalid + Status.
+#[tokio::test]
+#[ignore = "blocked on issue #TBD: Pod create accepts `spec: null` and persists an empty Pod (201) instead of 422 Invalid — Pod.spec is Option<PodSpec> and the container check is gated on Some(spec)"]
+async fn test_malformed_spec_null() {
+    let router = spawn_router();
+    let body = br#"{"metadata":{"name":"p"},"spec":null}"#.to_vec();
+    let (status, body) = post_pod_raw(router, body).await;
+    assert_status_contract("spec_null", status, &body);
+}
+
+#[tokio::test]
+async fn test_malformed_integer_overflow() {
+    let router = spawn_router();
+    // 9223372036854775808 = i64::MAX + 1 — cannot fit Option<i64>.
+    let body = br#"{"metadata":{"name":"p"},"spec":{"activeDeadlineSeconds":9223372036854775808,"containers":[{"name":"c","image":"i"}]}}"#.to_vec();
+    let (status, body) = post_pod_raw(router, body).await;
+    assert_status_contract("integer_overflow", status, &body);
+}
+
+// `serde_json` enforces a recursion limit (~128 by default) to prevent stack
+// overflow on adversarial input — 10_000 nested arrays produce a syntax error.
+// Pins the contract: rusternetes (via serde_json) REJECTS deeply nested JSON.
+#[tokio::test]
+async fn test_malformed_deeply_nested() {
+    let router = spawn_router();
+    let depth = 10_000usize;
+    let mut body = vec![b'['; depth];
+    body.resize(depth * 2, b']');
+    let (status, body) = post_pod_raw(router, body).await;
+    assert_status_contract("deeply_nested", status, &body);
+}
+
+// `serde_json::from_slice` reads to end-of-input and reports `trailing
+// characters` when garbage follows a complete value.
+#[tokio::test]
+async fn test_malformed_trailing_garbage() {
+    let router = spawn_router();
+    let (status, body) = post_pod_raw(router, br#"{"kind":"Pod"}garbage"#.to_vec()).await;
+    assert_status_contract("trailing_garbage", status, &body);
+}
+
+// serde_json default: last-wins on duplicate keys. The decoded Pod has no
+// spec → no containers, so handler validation returns 422 Invalid + Status.
+// Contract pinned here: Status object, not 2xx.
+#[tokio::test]
+async fn test_malformed_duplicate_keys() {
+    let router = spawn_router();
+    let body = br#"{"kind":"Pod","kind":"Service","metadata":{"name":"p"}}"#.to_vec();
+    let (status, body) = post_pod_raw(router, body).await;
+    assert_status_contract("duplicate_keys", status, &body);
+}
+
+#[tokio::test]
+async fn test_malformed_bare_string() {
+    let router = spawn_router();
+    let (status, body) = post_pod_raw(router, br#""hello""#.to_vec()).await;
+    assert_status_contract("bare_string", status, &body);
+}
+
+#[tokio::test]
+async fn test_malformed_bare_array() {
+    let router = spawn_router();
+    let (status, body) = post_pod_raw(router, br#"[]"#.to_vec()).await;
+    assert_status_contract("bare_array", status, &body);
+}

--- a/crates/api-server/tests/patch_cas_retry_test.rs
+++ b/crates/api-server/tests/patch_cas_retry_test.rs
@@ -1,0 +1,196 @@
+//! Regression tests for PATCH retry on resourceVersion conflict.
+//!
+//! Covers:
+//!   8f271ca  fix: PATCH retry on rv conflict + inline ObjectMeta
+//!             → generic_patch.rs: retry once on Error::Conflict from storage.update()
+//!   4f9111b  fix: scale PATCH retry on resourceVersion conflict
+//!             → scale.rs: retry up to 5 times on Error::Conflict from storage.update()
+//!
+//! Each test spins up a full `ApiServerState` backed by `StorageBackend::Memory`
+//! (pointing to an `Arc<MemoryStorage>` with conflict injection), builds the
+//! Axum router, and sends a real HTTP PATCH request through tower's `oneshot`.
+//! The `MemoryStorage::inject_conflicts(1)` call primes the storage to return
+//! `Error::Conflict` on the *first* `update()` call, simulating the etcd CAS
+//! mismatch that triggered these fixes.
+//!
+//! Revert scenario: reverting the retry loop causes the Conflict to be surfaced
+//! to the client as HTTP 409 instead of the expected 200.
+
+use axum::{body::Body, http::Request};
+use rusternetes_api_server::{router::build_router, state::ApiServerState};
+use rusternetes_common::auth::TokenManager;
+use rusternetes_common::authz::AlwaysAllowAuthorizer;
+use rusternetes_common::observability::MetricsRegistry;
+use rusternetes_storage::{build_key, memory::MemoryStorage, Storage, StorageBackend};
+use serde_json::{json, Value};
+use std::sync::Arc;
+use tower::ServiceExt;
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/// Construct a minimal `ApiServerState` backed by the given `MemoryStorage`.
+/// `skip_auth = true` so the router uses `skip_auth_middleware` and no token
+/// is needed.
+fn make_state(mem: Arc<MemoryStorage>) -> Arc<ApiServerState> {
+    let backend = Arc::new(StorageBackend::Memory(mem));
+    let token_manager = Arc::new(TokenManager::new(b"test-secret"));
+    let authorizer = Arc::new(AlwaysAllowAuthorizer);
+    let metrics = Arc::new(MetricsRegistry::new());
+    Arc::new(ApiServerState::new(
+        backend,
+        token_manager,
+        authorizer,
+        metrics,
+        true, // skip_auth
+    ))
+}
+
+/// Send a PATCH request to `uri` with the given JSON body and
+/// `Content-Type: application/merge-patch+json`.
+/// Returns the HTTP status code and the response body as a `serde_json::Value`.
+async fn patch_json(state: Arc<ApiServerState>, uri: &str, body: &Value) -> (u16, Value) {
+    let router = build_router(state, None);
+    let body_bytes = serde_json::to_vec(body).unwrap();
+    let req = Request::builder()
+        .method("PATCH")
+        .uri(uri)
+        .header("content-type", "application/merge-patch+json")
+        .body(Body::from(body_bytes))
+        .unwrap();
+    let response = router.oneshot(req).await.unwrap();
+    let status = response.status().as_u16();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body_json: Value = serde_json::from_slice(&body_bytes).unwrap_or(json!(null));
+    (status, body_json)
+}
+
+// ---------------------------------------------------------------------------
+// 8f271ca  — generic PATCH retry
+// ---------------------------------------------------------------------------
+
+/// Regression test for commit 8f271ca.
+///
+/// The fix adds a retry branch in `patch_namespaced_resource`: when
+/// `storage.update()` returns `Error::Conflict`, re-read the resource, re-apply
+/// the patch, and try again.
+///
+/// Without the fix, the first `Conflict` would be propagated to the client as
+/// HTTP 409. With the fix, the handler retries and returns HTTP 200 with the
+/// patched resource.
+#[tokio::test]
+async fn test_patch_generic_retries_on_conflict() {
+    let mem = Arc::new(MemoryStorage::new());
+
+    // Pre-create a ConfigMap so the handler finds it.
+    let cm = json!({
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {
+            "name": "cm-retry-test",
+            "namespace": "default"
+        },
+        "data": {
+            "key": "original"
+        }
+    });
+    let key = build_key("configmaps", Some("default"), "cm-retry-test");
+    mem.create(&key, &cm).await.unwrap();
+
+    // Arm the conflict injector: the NEXT update() call returns Error::Conflict.
+    mem.inject_conflicts(1);
+
+    let state = make_state(mem.clone());
+    let patch = json!({"data": {"key": "patched"}});
+    let (status, body) = patch_json(
+        state,
+        "/api/v1/namespaces/default/configmaps/cm-retry-test",
+        &patch,
+    )
+    .await;
+
+    println!("status={} body={}", status, body);
+
+    assert_eq!(
+        status, 200,
+        "PATCH must succeed (200) even when the first update() returns Conflict; \
+         got {} — did the retry loop get reverted? body={}",
+        status, body
+    );
+    assert_eq!(
+        body["data"]["key"], "patched",
+        "Patch must be applied in the retried write"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4f9111b  — scale PATCH retry
+// ---------------------------------------------------------------------------
+
+/// Regression test for the scale-PATCH sub-fix in commit 4f9111b.
+///
+/// The fix wraps the `get + update` loop in `patch_scale` with a retry: on
+/// `Error::Conflict`, re-read the resource and retry the write.
+///
+/// Without the fix, the first `Conflict` is returned to the client as HTTP 409.
+/// With the fix, the handler retries and returns HTTP 200 with the patched scale.
+#[tokio::test]
+async fn test_patch_scale_retries_on_conflict() {
+    let mem = Arc::new(MemoryStorage::new());
+
+    // Pre-create a Deployment so patch_scale can find it.
+    let deployment = json!({
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+            "name": "scale-retry-deploy",
+            "namespace": "default"
+        },
+        "spec": {
+            "replicas": 2,
+            "selector": {
+                "matchLabels": {"app": "scale-retry"}
+            },
+            "template": {
+                "metadata": {"labels": {"app": "scale-retry"}},
+                "spec": {
+                    "containers": [{"name": "app", "image": "nginx:latest"}]
+                }
+            }
+        },
+        "status": {
+            "replicas": 2
+        }
+    });
+    let key = build_key("deployments", Some("default"), "scale-retry-deploy");
+    mem.create(&key, &deployment).await.unwrap();
+
+    // Arm the conflict injector.
+    mem.inject_conflicts(1);
+
+    let state = make_state(mem.clone());
+    // K8s scale PATCH body: {"spec":{"replicas": N}}
+    let patch = json!({"spec": {"replicas": 5}});
+    let (status, body) = patch_json(
+        state,
+        "/apis/apps/v1/namespaces/default/deployments/scale-retry-deploy/scale",
+        &patch,
+    )
+    .await;
+
+    println!("status={} body={}", status, body);
+
+    assert_eq!(
+        status, 200,
+        "Scale PATCH must succeed (200) even when the first update() returns Conflict; \
+         got {} — did the retry loop in patch_scale get reverted? body={}",
+        status, body
+    );
+    assert_eq!(
+        body["spec"]["replicas"], 5,
+        "Replicas must reflect the patched value"
+    );
+}

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use rusternetes_common::authz::AuthzStorage;
 use rusternetes_common::Result;
 use serde::{de::DeserializeOwned, Serialize};
+use std::sync::Arc;
 
 pub mod concurrency;
 pub mod etcd;
@@ -152,7 +153,7 @@ pub enum StorageConfig {
     },
 }
 
-/// Unified storage backend that dispatches to etcd, SQLite, or Redis at runtime.
+/// Unified storage backend that dispatches to etcd, SQLite, Redis, or in-memory at runtime.
 ///
 /// This allows all components to remain generic over `S: Storage` while the
 /// concrete backend is chosen once at startup via `StorageConfig`.
@@ -163,6 +164,9 @@ pub enum StorageBackend {
     Sqlite(RhinoStorage),
     #[cfg(feature = "redis")]
     Redis(RhinoRedisStorage),
+    /// In-memory backend backed by `MemoryStorage`. Intended for unit/integration
+    /// tests that need a full `ApiServerState` without an external store.
+    Memory(Arc<MemoryStorage>),
 }
 
 impl StorageBackend {
@@ -185,6 +189,14 @@ impl StorageBackend {
             }
         }
     }
+
+    /// Construct an in-memory backend suitable for unit/integration tests.
+    /// Wraps `MemoryStorage` in an `Arc` so the same handle can be cloned by
+    /// the caller (e.g. for `inject_conflicts(...)`) while the enum owns one
+    /// copy.
+    pub fn new_memory() -> Self {
+        StorageBackend::Memory(Arc::new(MemoryStorage::new()))
+    }
 }
 
 #[async_trait]
@@ -199,6 +211,7 @@ impl Storage for StorageBackend {
             StorageBackend::Sqlite(s) => Storage::create(s, key, value).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => Storage::create(s, key, value).await,
+            StorageBackend::Memory(s) => Storage::create(s.as_ref(), key, value).await,
         }
     }
 
@@ -212,6 +225,7 @@ impl Storage for StorageBackend {
             StorageBackend::Sqlite(s) => Storage::get(s, key).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => Storage::get(s, key).await,
+            StorageBackend::Memory(s) => Storage::get(s.as_ref(), key).await,
         }
     }
 
@@ -225,6 +239,7 @@ impl Storage for StorageBackend {
             StorageBackend::Sqlite(s) => Storage::update(s, key, value).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => Storage::update(s, key, value).await,
+            StorageBackend::Memory(s) => Storage::update(s.as_ref(), key, value).await,
         }
     }
 
@@ -235,6 +250,7 @@ impl Storage for StorageBackend {
             StorageBackend::Sqlite(s) => Storage::update_raw(s, key, value).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => Storage::update_raw(s, key, value).await,
+            StorageBackend::Memory(s) => Storage::update_raw(s.as_ref(), key, value).await,
         }
     }
 
@@ -245,6 +261,7 @@ impl Storage for StorageBackend {
             StorageBackend::Sqlite(s) => Storage::delete(s, key).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => Storage::delete(s, key).await,
+            StorageBackend::Memory(s) => Storage::delete(s.as_ref(), key).await,
         }
     }
 
@@ -258,6 +275,7 @@ impl Storage for StorageBackend {
             StorageBackend::Sqlite(s) => Storage::list(s, prefix).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => Storage::list(s, prefix).await,
+            StorageBackend::Memory(s) => Storage::list(s.as_ref(), prefix).await,
         }
     }
 
@@ -268,6 +286,7 @@ impl Storage for StorageBackend {
             StorageBackend::Sqlite(s) => Storage::watch(s, prefix).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => Storage::watch(s, prefix).await,
+            StorageBackend::Memory(s) => Storage::watch(s.as_ref(), prefix).await,
         }
     }
 
@@ -278,6 +297,9 @@ impl Storage for StorageBackend {
             StorageBackend::Sqlite(s) => Storage::watch_from_revision(s, prefix, revision).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => Storage::watch_from_revision(s, prefix, revision).await,
+            StorageBackend::Memory(s) => {
+                Storage::watch_from_revision(s.as_ref(), prefix, revision).await
+            }
         }
     }
 
@@ -288,6 +310,7 @@ impl Storage for StorageBackend {
             StorageBackend::Sqlite(s) => Storage::current_revision(s).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => Storage::current_revision(s).await,
+            StorageBackend::Memory(s) => Storage::current_revision(s.as_ref()).await,
         }
     }
 
@@ -298,6 +321,7 @@ impl Storage for StorageBackend {
             StorageBackend::Sqlite(s) => Storage::is_revision_compacted(s, revision).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => Storage::is_revision_compacted(s, revision).await,
+            StorageBackend::Memory(s) => Storage::is_revision_compacted(s.as_ref(), revision).await,
         }
     }
 }
@@ -315,6 +339,7 @@ impl rusternetes_common::authz::AuthzStorage for StorageBackend {
             StorageBackend::Sqlite(s) => AuthzStorage::get(s, key, namespace).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => AuthzStorage::get(s, key, namespace).await,
+            StorageBackend::Memory(s) => AuthzStorage::get(s.as_ref(), key, namespace).await,
         }
     }
 
@@ -328,6 +353,7 @@ impl rusternetes_common::authz::AuthzStorage for StorageBackend {
             StorageBackend::Sqlite(s) => AuthzStorage::list(s, namespace).await,
             #[cfg(feature = "redis")]
             StorageBackend::Redis(s) => AuthzStorage::list(s, namespace).await,
+            StorageBackend::Memory(s) => AuthzStorage::list(s.as_ref(), namespace).await,
         }
     }
 }

--- a/crates/storage/src/memory.rs
+++ b/crates/storage/src/memory.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 use rusternetes_common::{Error, Result};
 use serde::{de::DeserializeOwned, Serialize};
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 use tokio::sync::broadcast;
 
@@ -12,6 +13,9 @@ pub struct MemoryStorage {
     data: Arc<RwLock<HashMap<String, String>>>,
     // Broadcast channel for watch events
     watch_tx: broadcast::Sender<WatchEvent>,
+    /// Number of remaining update() calls that will return Error::Conflict
+    /// before delegating to the real update. Used by tests to inject CAS conflicts.
+    conflict_update_count: Arc<AtomicUsize>,
 }
 
 impl MemoryStorage {
@@ -21,6 +25,7 @@ impl MemoryStorage {
         Self {
             data: Arc::new(RwLock::new(HashMap::new())),
             watch_tx,
+            conflict_update_count: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -37,6 +42,12 @@ impl MemoryStorage {
     /// Check if storage is empty
     pub fn is_empty(&self) -> bool {
         self.data.read().unwrap().is_empty()
+    }
+
+    /// Arrange for the next `n` calls to `update()` to return `Error::Conflict`.
+    /// Subsequent calls behave normally. Used by tests to verify retry logic.
+    pub fn inject_conflicts(&self, n: usize) {
+        self.conflict_update_count.store(n, Ordering::SeqCst);
     }
 }
 
@@ -117,6 +128,22 @@ impl Storage for MemoryStorage {
     where
         T: Serialize + DeserializeOwned + Send + Sync,
     {
+        // Inject a Conflict error if requested by a test (see inject_conflicts).
+        if self.conflict_update_count.load(Ordering::SeqCst) > 0 {
+            let prev =
+                self.conflict_update_count
+                    .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| {
+                        if v > 0 {
+                            Some(v - 1)
+                        } else {
+                            None
+                        }
+                    });
+            if prev.is_ok() {
+                return Err(Error::Conflict("injected conflict for test".to_string()));
+            }
+        }
+
         let serialized = serde_json::to_string(value)?;
 
         let mut data = self.data.write().unwrap();
@@ -218,6 +245,72 @@ impl Storage for MemoryStorage {
 
     async fn is_revision_compacted(&self, _revision: i64) -> Result<bool> {
         Ok(false) // Memory storage never compacts
+    }
+}
+
+// AuthzStorage for MemoryStorage — used when StorageBackend::Memory is selected.
+// The RBAC queries in tests use AlwaysAllowAuthorizer so these methods are
+// typically not called; they're implemented for completeness.
+#[async_trait::async_trait]
+impl rusternetes_common::authz::AuthzStorage for MemoryStorage {
+    async fn get<T>(&self, key: &str, namespace: Option<&str>) -> rusternetes_common::Result<T>
+    where
+        T: serde::de::DeserializeOwned + Send + Sync,
+    {
+        use crate::build_key;
+        // Mirror the EtcdStorage pattern: derive a full /registry path from type name.
+        let full_key = match namespace {
+            Some(ns) => {
+                let tn = std::any::type_name::<T>();
+                if tn.contains("Role") && !tn.contains("Cluster") {
+                    format!("/registry/roles/{}/{}", ns, key)
+                } else if tn.contains("RoleBinding") && !tn.contains("Cluster") {
+                    format!("/registry/rolebindings/{}/{}", ns, key)
+                } else {
+                    build_key("unknown", Some(ns), key)
+                }
+            }
+            None => {
+                let tn = std::any::type_name::<T>();
+                if tn.contains("ClusterRole") && !tn.contains("Binding") {
+                    format!("/registry/clusterroles/{}", key)
+                } else if tn.contains("ClusterRoleBinding") {
+                    format!("/registry/clusterrolebindings/{}", key)
+                } else {
+                    format!("/registry/unknown/{}", key)
+                }
+            }
+        };
+        Storage::get(self, &full_key).await
+    }
+
+    async fn list<T>(&self, namespace: Option<&str>) -> rusternetes_common::Result<Vec<T>>
+    where
+        T: serde::Serialize + serde::de::DeserializeOwned + Send + Sync,
+    {
+        let prefix = match namespace {
+            Some(ns) => {
+                let tn = std::any::type_name::<T>();
+                if tn.contains("Role") && !tn.contains("Cluster") {
+                    format!("/registry/roles/{}/", ns)
+                } else if tn.contains("RoleBinding") && !tn.contains("Cluster") {
+                    format!("/registry/rolebindings/{}/", ns)
+                } else {
+                    format!("/registry/unknown/{}/", ns)
+                }
+            }
+            None => {
+                let tn = std::any::type_name::<T>();
+                if tn.contains("ClusterRole") && !tn.contains("Binding") {
+                    "/registry/clusterroles/".to_string()
+                } else if tn.contains("ClusterRoleBinding") {
+                    "/registry/clusterrolebindings/".to_string()
+                } else {
+                    "/registry/unknown/".to_string()
+                }
+            }
+        };
+        Storage::list(self, &prefix).await
     }
 }
 


### PR DESCRIPTION
## Summary

Two changes that close client-go-parity gaps around malformed request bodies.

### Fix: reject Pod CREATE with \`spec: null\`

Upstream returns 422 Invalid for \`POST /api/v1/namespaces/{ns}/pods\` with \`spec: null\`. We previously accepted it and persisted an empty Pod with HTTP 201. Pod handler now returns a Status object \`{kind: Status, status: Failure, reason: Invalid, message: \"spec.containers: Required value\"}\` before the \`Some(spec)\` block, matching upstream wording.

### Tests: malformed-JSON envelope contract

\`crates/api-server/tests/decoder_malformed_json_test.rs\` — 14 fixtures asserting the response to every malformed body is a Status object (kind=Status, apiVersion=v1, status=Failure, reason ∈ {BadRequest, Invalid}) with HTTP ∈ {400, 422} — never plain text, never empty. Covers:

- empty body, bare string, bare array, truncated key-only / open-brace / open-bracket
- duplicate keys, trailing garbage, invalid UTF-8, integer overflow, deeply nested
- wrong-type metadata, wrong-type activeDeadlineSeconds, \`spec: null\` (which was the original \`#[ignore]\`d case the fix unpins)

## Stacked on

Depends on #51 (StorageBackend::Memory variant).

## Test plan

- [x] \`cargo test -p rusternetes-api-server --test decoder_malformed_json_test\` — 14/14 pass
- [x] \`cargo fmt --all -- --check\` clean