### PR TITLE
fix: add protobuf build dependencies and switch rhino to git dep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Rust reimplementation of Kubernetes. Workspace with 10 crates:
 
 - **`common`** - Shared resource types (Pod, Deployment, Service, etc.), error types, utilities. All resource structs live in `src/resources/`. Error type in `src/error.rs` maps to Kubernetes StatusReason and implements Axum's `IntoResponse`.
 - **`api-server`** - Axum-based REST API. Routes in `src/router.rs` (~9400 lines). One handler file per resource type in `src/handlers/`. State in `src/state.rs` holds storage, auth, IP allocator, webhook manager, watch cache.
-- **`storage`** - `Storage` trait in `src/lib.rs` with etcd backend (`src/etcd.rs`), SQLite backend via rhino (`src/rhino.rs`, behind `sqlite` feature), Redis backend via rhino (`src/rhino.rs`, behind `redis` feature), and memory backend (`src/memory.rs`). `StorageBackend` enum dispatches to the selected backend. Keys follow `/registry/{resource_type}/{namespace}/{name}`. Resource versions map to backend revision numbers. The rhino dependency uses a local path (`../../../rhino`).
+- **`storage`** - `Storage` trait in `src/lib.rs` with etcd backend (`src/etcd.rs`), SQLite backend via rhino (`src/rhino.rs`, behind `sqlite` feature), Redis backend via rhino (`src/rhino.rs`, behind `redis` feature), and memory backend (`src/memory.rs`). `StorageBackend` enum dispatches to the selected backend. Keys follow `/registry/{resource_type}/{namespace}/{name}`. Resource versions map to backend revision numbers. The rhino dependency is a git dependency (`https://github.com/calfonso/rhino`, main branch).
 - **`controller-manager`** - 31 controllers in `src/controllers/`. Each has a struct with `storage: Arc<S>` + `interval: Duration`, an infinite `run()` loop, and `reconcile_one()` per resource.
 - **`kubelet`** - Container runtime via bollard (Docker API). Manages pod lifecycle, volumes, probes, networking.
 - **`kube-proxy`** - iptables-based service routing. Runs in host network mode. Reads both Endpoints and EndpointSlices.
@@ -110,4 +110,4 @@ Single `rusternetes` binary container + optional Redis container. All components
 - kube-proxy needs `CAP_NET_ADMIN` for iptables; runs host network mode
 - `KUBERNETES_SERVICE_HOST_OVERRIDE` env var sets the API server address for pods
 - CoreDNS ClusterIP pinned to 10.96.0.10
-- Rhino repo must be adjacent (`../rhino`) for SQLite/Redis embedded builds
+- Rhino repo must be adjacent (`../rhino`) for compose builds that use `Dockerfile.rhino` (SQLite/Redis multi-container modes)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3570,6 +3570,7 @@ dependencies = [
 [[package]]
 name = "rhino"
 version = "0.1.0"
+source = "git+https://github.com/calfonso/rhino?branch=main#7f2bd02ca55eab4f6d9dbeef50e29bd993412c95"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Dockerfile.all-in-one
+++ b/Dockerfile.all-in-one
@@ -1,7 +1,7 @@
 # Dockerfile for the all-in-one rusternetes binary.
 #
-# Build context must be the PARENT directory of both rusternetes/ and rhino/
-# so that the rhino crate path (../../../rhino from crates/storage) resolves.
+# Cargo fetches the rhino crate from git automatically — no adjacent
+# clone required.
 #
 # Build args:
 #   CARGO_FEATURES — cargo features to enable (default: "sqlite")
@@ -9,17 +9,17 @@
 #
 # Usage (from compose):
 #   build:
-#     context: ..
-#     dockerfile: rusternetes/Dockerfile.all-in-one
+#     context: .
+#     dockerfile: Dockerfile.all-in-one
 #     args:
 #       CARGO_FEATURES: redis
 
 # Stage 1: Build the console SPA
 FROM node:26-slim AS console-builder
 WORKDIR /console
-COPY rusternetes/console/package.json rusternetes/console/package-lock.json* ./
+COPY console/package.json console/package-lock.json* ./
 RUN npm ci --ignore-scripts
-COPY rusternetes/console/ ./
+COPY console/ ./
 RUN npm run build
 
 # Stage 2: Build the Rust binary
@@ -33,31 +33,25 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /build
 
-# Copy rhino crate first (dependency)
-COPY rhino/Cargo.toml rhino/Cargo.lock rhino/build.rs ./rhino/
-COPY rhino/proto/ ./rhino/proto/
-COPY rhino/src/ ./rhino/src/
-
-# Copy rusternetes workspace manifest
-COPY rusternetes/Cargo.toml rusternetes/Cargo.lock* ./rusternetes/
+# Copy workspace manifest
+COPY Cargo.toml Cargo.lock* ./
 
 # Copy all crate manifests for layer caching
-COPY rusternetes/crates/rusternetes/Cargo.toml ./rusternetes/crates/rusternetes/
-COPY rusternetes/crates/api-server/Cargo.toml ./rusternetes/crates/api-server/
-COPY rusternetes/crates/common/Cargo.toml ./rusternetes/crates/common/
-COPY rusternetes/crates/storage/Cargo.toml ./rusternetes/crates/storage/
-COPY rusternetes/crates/scheduler/Cargo.toml ./rusternetes/crates/scheduler/
-COPY rusternetes/crates/controller-manager/Cargo.toml ./rusternetes/crates/controller-manager/
-COPY rusternetes/crates/kubelet/Cargo.toml ./rusternetes/crates/kubelet/
-COPY rusternetes/crates/kube-proxy/Cargo.toml ./rusternetes/crates/kube-proxy/
-COPY rusternetes/crates/kubectl/Cargo.toml ./rusternetes/crates/kubectl/
+COPY crates/rusternetes/Cargo.toml ./crates/rusternetes/
+COPY crates/api-server/Cargo.toml ./crates/api-server/
+COPY crates/common/Cargo.toml ./crates/common/
+COPY crates/storage/Cargo.toml ./crates/storage/
+COPY crates/scheduler/Cargo.toml ./crates/scheduler/
+COPY crates/controller-manager/Cargo.toml ./crates/controller-manager/
+COPY crates/kubelet/Cargo.toml ./crates/kubelet/
+COPY crates/kube-proxy/Cargo.toml ./crates/kube-proxy/
+COPY crates/kubectl/Cargo.toml ./crates/kubectl/
 
 # Copy all source code
-COPY rusternetes/crates ./rusternetes/crates
+COPY crates ./crates
 
 # Build the all-in-one binary
 ARG CARGO_FEATURES=sqlite
-WORKDIR /build/rusternetes
 RUN cargo build --release --features ${CARGO_FEATURES} -p rusternetes
 
 # Stage 3: Runtime image
@@ -70,7 +64,7 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /app
 
-COPY --from=builder /build/rusternetes/target/release/rusternetes /app/rusternetes
+COPY --from=builder /build/target/release/rusternetes /app/rusternetes
 COPY --from=console-builder /console/dist /app/console
 
 EXPOSE 6443 10250

--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ Rusternetes supports multiple deployment modes from the same codebase:
 
 The all-in-one mode is built for environments where a full K8s cluster is overkill: edge devices, CI/CD pipelines, local development, IoT gateways, embedded systems, and air-gapped environments.
 
+## Prerequisites
+
+- **Rust** (latest stable) — install via [rustup.rs](https://rustup.rs/)
+- **Protocol Buffers compiler** — required for building the API server
+  - Fedora/RHEL: `sudo dnf install -y protobuf-compiler protobuf-devel`
+  - Debian/Ubuntu: `sudo apt install -y protobuf-compiler`
+  - macOS: `brew install protobuf`
+- **Container runtime** — Docker or Podman
+
 ## Quick Start
 
 ### Full cluster (Podman + etcd)

--- a/compose.all-in-one-redis.yml
+++ b/compose.all-in-one-redis.yml
@@ -8,11 +8,6 @@
 #   podman compose -f compose.all-in-one-redis.yml build
 #   podman compose -f compose.all-in-one-redis.yml up -d
 #
-# Requires the rhino repo adjacent to this one:
-#   dev/
-#     rusternetes/   (this repo)
-#     rhino/         (https://github.com/calfonso/rhino)
-
 services:
   redis:
     image: docker.io/library/redis:7-alpine
@@ -32,8 +27,8 @@ services:
 
   rusternetes:
     build:
-      context: ..
-      dockerfile: rusternetes/Dockerfile.all-in-one
+      context: .
+      dockerfile: Dockerfile.all-in-one
       args:
         CARGO_FEATURES: redis
     container_name: rusternetes

--- a/compose.all-in-one.yml
+++ b/compose.all-in-one.yml
@@ -7,16 +7,11 @@
 #   podman compose -f compose.all-in-one.yml build
 #   podman compose -f compose.all-in-one.yml up -d
 #
-# Requires the rhino repo adjacent to this one:
-#   dev/
-#     rusternetes/   (this repo)
-#     rhino/         (https://github.com/calfonso/rhino)
-
 services:
   rusternetes:
     build:
-      context: ..
-      dockerfile: rusternetes/Dockerfile.all-in-one
+      context: .
+      dockerfile: Dockerfile.all-in-one
       args:
         CARGO_FEATURES: sqlite
     container_name: rusternetes

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -12,7 +12,7 @@ redis = ["dep:rhino"]
 
 [dependencies]
 rusternetes-common = { path = "../common" }
-rhino = { path = "../../../rhino", optional = true }
+rhino = { git = "https://github.com/calfonso/rhino", branch = "main", optional = true }
 tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -5,6 +5,7 @@ Thank you for your interest in contributing to Rusternetes. This is a Rust reimp
 ## Prerequisites
 
 - Rust (stable toolchain)
+- Protocol Buffers compiler (`protobuf-compiler` + `protobuf-devel` on Fedora, `protobuf-compiler` on Debian/Ubuntu, `brew install protobuf` on macOS)
 - Docker and Docker Compose (for integration testing)
 - `make` (for convenience targets)
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -5,6 +5,10 @@ How to build, test, and run Rusternetes locally.
 ## Prerequisites
 
 - **Rust** (latest stable, via [rustup](https://rustup.rs))
+- **Protocol Buffers compiler** — required for building the API server
+  - Fedora/RHEL: `sudo dnf install -y protobuf-compiler protobuf-devel`
+  - Debian/Ubuntu: `sudo apt install -y protobuf-compiler`
+  - macOS: `brew install protobuf`
 - **Container runtime** — Docker or Podman (see [Container Runtime Setup](#container-runtime-setup) below)
 - **Compose tool** — `docker-compose` and/or `podman-compose` for orchestrating the cluster
 

--- a/docs/FEDORA_SETUP.md
+++ b/docs/FEDORA_SETUP.md
@@ -56,6 +56,8 @@ sudo dnf install -y \
     make \
     openssl-devel \
     pkg-config \
+    protobuf-compiler \
+    protobuf-devel \
     lsof
 ```
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -7,6 +7,7 @@ This guide shows how to run each rusternetes component as a separate process on 
 ## Prerequisites
 
 - **Rust toolchain** — install via [rustup.rs](https://rustup.rs/)
+- **Protocol Buffers compiler** — `protobuf-compiler` + `protobuf-devel` (Fedora), `protobuf-compiler` (Debian/Ubuntu), `brew install protobuf` (macOS)
 - **etcd** — for cluster state storage (or use SQLite/Redis with the all-in-one binary)
 - **Docker** — for the kubelet to create containers
 

--- a/docs/guide/installation.html
+++ b/docs/guide/installation.html
@@ -548,15 +548,15 @@ sudo podman compose -f compose.yml up -d</code>
         <tbody>
           <tr>
             <td>Ubuntu / Debian</td>
-            <td><code>build-essential pkg-config libssl-dev</code></td>
+            <td><code>build-essential pkg-config libssl-dev protobuf-compiler</code></td>
           </tr>
           <tr>
             <td>Fedora / RHEL</td>
-            <td><code>gcc openssl-devel pkg-config</code></td>
+            <td><code>gcc openssl-devel pkg-config protobuf-compiler protobuf-devel</code></td>
           </tr>
           <tr>
             <td>macOS</td>
-            <td>Xcode Command Line Tools (<code>xcode-select --install</code>)</td>
+            <td>Xcode Command Line Tools (<code>xcode-select --install</code>), <code>brew install protobuf</code></td>
           </tr>
         </tbody>
       </table>
@@ -569,13 +569,14 @@ sudo podman compose -f compose.yml up -d</code>
           <span class="code-title">terminal</span>
         </div>
         <code><span class="comment"># Ubuntu / Debian</span>
-sudo apt-get install -y build-essential pkg-config libssl-dev
+sudo apt-get install -y build-essential pkg-config libssl-dev protobuf-compiler
 
 <span class="comment"># Fedora / RHEL</span>
-sudo dnf install -y gcc openssl-devel pkg-config
+sudo dnf install -y gcc openssl-devel pkg-config protobuf-compiler protobuf-devel
 
 <span class="comment"># macOS (if not already installed)</span>
-xcode-select --install</code>
+xcode-select --install
+brew install protobuf</code>
       </pre>
 
       <h2>Verify Your Installation</h2>

--- a/scripts/dev-setup-fedora.sh
+++ b/scripts/dev-setup-fedora.sh
@@ -165,6 +165,8 @@ install_system_packages() {
         make \
         openssl-devel \
         pkg-config \
+        protobuf-compiler \
+        protobuf-devel \
         lsof \
         gettext
 

--- a/scripts/dev-setup-macos.sh
+++ b/scripts/dev-setup-macos.sh
@@ -55,6 +55,11 @@ if ! check_command "cargo"; then
     MISSING_DEPS=1
 fi
 
+if ! check_command "protoc"; then
+    echo "  Install protobuf: brew install protobuf"
+    MISSING_DEPS=1
+fi
+
 # Check for Docker or Podman (prefer Docker on macOS)
 CONTAINER_RUNTIME=""
 if check_command "docker"; then


### PR DESCRIPTION
## Summary

- Switch the `rhino` storage dependency from a local path (`../../../rhino`) to a git dependency on the `main` branch, so the workspace builds without needing an adjacent clone.
- Document `protobuf-compiler` and `protobuf-devel` as build prerequisites across all developer-facing docs, setup scripts, and the HTML documentation site.

## Files changed

| File | Change |
|------|--------|
| `crates/storage/Cargo.toml` | rhino: path → git dependency |
| `README.md` | Added Prerequisites section |
| `docs/DEVELOPMENT.md` | Added protobuf to prerequisites |
| `docs/CONTRIBUTING.md` | Added protobuf to prerequisites |
| `docs/GETTING_STARTED.md` | Added protobuf to prerequisites |
| `docs/FEDORA_SETUP.md` | Added packages to `dnf install` block |
| `docs/guide/installation.html` | Added protobuf to build deps table and commands |
| `scripts/dev-setup-fedora.sh` | Added packages to `install_system_packages()` |
| `scripts/dev-setup-macos.sh` | Added `protoc` prerequisite check |

## Test plan

- [x] `cargo build` succeeds without a local rhino clone

Assisted-by: Claude <noreply@anthropic.com>