### PR TITLE
fix: deprecation warnings; moved to rand 0.9 API

### DIFF
--- a/crates/controller-manager/src/controllers/daemonset.rs
+++ b/crates/controller-manager/src/controllers/daemonset.rs
@@ -884,11 +884,11 @@ impl<S: Storage + 'static> DaemonSetController<S> {
         // returns NotFound via GET.
         let suffix: String = {
             use rand::Rng;
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
             (0..5)
                 .map(|_| {
                     const CHARSET: &[u8] = b"bcdfghjklmnpqrstvwxz2456789";
-                    CHARSET[rng.gen_range(0..CHARSET.len())] as char
+                    CHARSET[rng.random_range(0..CHARSET.len())] as char
                 })
                 .collect()
         };

--- a/crates/controller-manager/src/controllers/deployment.rs
+++ b/crates/controller-manager/src/controllers/deployment.rs
@@ -1208,7 +1208,7 @@ impl<S: Storage + 'static> DeploymentController<S> {
                             Ok(_) => break,
                             Err(rusternetes_common::Error::Conflict(_)) => {
                                 if attempt + 1 < 3 {
-                                    let jitter = rand::thread_rng().gen_range(0..delay_ms);
+                                    let jitter = rand::rng().random_range(0..delay_ms);
                                     tokio::time::sleep(Duration::from_millis(delay_ms + jitter))
                                         .await;
                                     delay_ms = (delay_ms * 2).min(500);

--- a/crates/controller-manager/src/controllers/vpa.rs
+++ b/crates/controller-manager/src/controllers/vpa.rs
@@ -351,7 +351,7 @@ impl<S: Storage + 'static> VerticalPodAutoscalerController<S> {
         container: &rusternetes_common::resources::Container,
     ) -> (i64, i64) {
         use rand::Rng;
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         // Get CPU request (default to 100m if not specified)
         let cpu_request = container
@@ -372,8 +372,8 @@ impl<S: Storage + 'static> VerticalPodAutoscalerController<S> {
             .unwrap_or(128 * 1024 * 1024);
 
         // Simulate usage as 60-90% of request with some variance
-        let cpu_usage = (cpu_request as f64 * (0.6 + rng.gen::<f64>() * 0.3)) as i64;
-        let memory_usage = (memory_request as f64 * (0.6 + rng.gen::<f64>() * 0.3)) as i64;
+        let cpu_usage = (cpu_request as f64 * (0.6 + rng.random::<f64>() * 0.3)) as i64;
+        let memory_usage = (memory_request as f64 * (0.6 + rng.random::<f64>() * 0.3)) as i64;
 
         (cpu_usage, memory_usage)
     }


### PR DESCRIPTION
Resolve deprecation warnings for:
```
warning: use of deprecated function `rand::thread_rng`: Renamed to `rng`
warning: use of deprecated method `rand::Rng::gen_range`: Renamed to `random_range`
warning: use of deprecated method `rand::Rng::gen`: Renamed to `random` to avoid conflict with the new `gen` keyword in Rust 2024.
```