### PR TITLE
fix(kubelet): skip uts_mode=container: on Docker so pods can start

### DIFF
--- a/crates/kubelet/src/runtime.rs
+++ b/crates/kubelet/src/runtime.rs
@@ -92,6 +92,9 @@ pub struct ContainerRuntime {
     network: String,
     cni: Option<CniRuntime>,
     use_cni: bool,
+    /// Whether the daemon accepts `UtsMode: "container:<id>"`. Podman does;
+    /// Docker rejects it outright. See [`Self::detect_uts_container_mode`].
+    supports_uts_container_mode: bool,
     kubernetes_service_host: String,
     /// Token manager for generating projected service account tokens
     token_manager: rusternetes_common::auth::TokenManager,
@@ -215,6 +218,8 @@ impl ContainerRuntime {
             .unwrap_or_else(|_| "rusternetes-secret-change-in-production".to_string());
         let token_manager = rusternetes_common::auth::TokenManager::new_auto(jwt_secret.as_bytes());
 
+        let supports_uts_container_mode = Self::detect_uts_container_mode(&docker).await;
+
         Ok(Self {
             docker,
             storage: None,
@@ -224,12 +229,73 @@ impl ContainerRuntime {
             network,
             cni,
             use_cni,
+            supports_uts_container_mode,
             kubernetes_service_host,
             token_manager,
             probe_states: Mutex::new(HashMap::new()),
             image_cache: Mutex::new(std::collections::HashSet::new()),
             shell_cache: Mutex::new(HashMap::new()),
         })
+    }
+
+    /// Classify a daemon identity string as Podman, Docker, or unknown.
+    ///
+    /// Split out from [`Self::detect_uts_container_mode`] so the matching
+    /// rules can be unit-tested without a live daemon.
+    fn uts_container_mode_from_identity(identity: &str) -> bool {
+        let identity = identity.to_lowercase();
+        if identity.contains("podman") {
+            true
+        } else if identity.contains("docker") {
+            false
+        } else {
+            // Unrecognised daemon: keep the pre-existing behaviour.
+            true
+        }
+    }
+
+    /// Determine whether the daemon accepts `UtsMode: "container:<id>"`.
+    ///
+    /// Joining another container's UTS namespace is a Podman extension.
+    /// Docker only accepts `""` or `"host"` and fails container creation with
+    /// `400 invalid UTS mode` for anything else, so setting the field there
+    /// makes every pod unstartable.
+    ///
+    /// Podman's Docker-compatible `/version` endpoint identifies itself as
+    /// "Podman Engine" in `Components[].Name`; Docker reports "Engine" plus a
+    /// `Platform.Name` of "Docker Engine - <edition>". Anything we cannot
+    /// positively identify as Docker keeps the previous behaviour.
+    async fn detect_uts_container_mode(docker: &Docker) -> bool {
+        let version = match docker.version().await {
+            Ok(version) => version,
+            Err(e) => {
+                // The daemon is unreachable; nothing else will work either.
+                // Don't change pod-creation behaviour off a failed probe.
+                warn!("Could not probe container runtime version: {}", e);
+                return true;
+            }
+        };
+
+        let identity = version
+            .platform
+            .as_ref()
+            .map(|p| p.name.as_str())
+            .into_iter()
+            .chain(version.components.iter().flatten().map(|c| c.name.as_str()))
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        let supported = Self::uts_container_mode_from_identity(&identity);
+        if supported {
+            debug!("Container runtime ({identity}) supports uts_mode=container:");
+        } else {
+            info!(
+                "Container runtime ({identity}) does not support \
+                 uts_mode=container:; pod containers will inherit the pod \
+                 hostname through the shared network namespace instead"
+            );
+        }
+        supported
     }
 
     /// Initialize CNI runtime
@@ -4400,8 +4466,18 @@ impl ContainerRuntime {
                 // Share UTS namespace with pause container so app containers
                 // inherit the pod hostname. Without this, containers get their
                 // container ID as hostname instead of the pod name.
-                // K8s CRI shares UTS via the pod sandbox; Docker/Podman need explicit uts_mode.
-                uts_mode: if using_container_network {
+                // K8s CRI shares UTS via the pod sandbox; Podman needs an
+                // explicit uts_mode.
+                //
+                // Docker has no equivalent: it accepts only ""/"host" for
+                // UtsMode and rejects container creation with `400 invalid UTS
+                // mode` otherwise, which previously left every pod stuck in a
+                // create-fail loop. It also refuses an explicit `hostname`
+                // alongside `network_mode: container:` ("conflicting options").
+                // Neither is needed there — Docker already propagates the
+                // target container's hostname when joining its network
+                // namespace, so the pod hostname is inherited regardless.
+                uts_mode: if using_container_network && self.supports_uts_container_mode {
                     Some(format!("container:{}_pause", pod_name))
                 } else {
                     None
@@ -8116,8 +8192,53 @@ pub fn parse_cpu_quantity(s: &str) -> i64 {
 
 #[cfg(test)]
 mod tests {
+    use super::ContainerRuntime;
     use rusternetes_common::resources::{Container, ContainerState, ContainerStatus, Pod, PodSpec};
     use rusternetes_common::types::{ObjectMeta, TypeMeta};
+
+    /// Docker rejects `UtsMode: "container:<id>"` with `400 invalid UTS mode`,
+    /// so it must be classified as unsupported; Podman accepts it.
+    #[test]
+    fn test_uts_container_mode_detection() {
+        // Docker CE reports this Platform.Name plus generic component names.
+        assert!(!ContainerRuntime::uts_container_mode_from_identity(
+            "Docker Engine - Community Engine containerd runc docker-init"
+        ));
+        assert!(!ContainerRuntime::uts_container_mode_from_identity(
+            "Docker Engine - Enterprise"
+        ));
+
+        // Podman's Docker-compatible /version names itself in Components[].
+        assert!(ContainerRuntime::uts_container_mode_from_identity(
+            "Podman Engine"
+        ));
+        assert!(ContainerRuntime::uts_container_mode_from_identity(
+            "linux/amd64 Podman Engine conmon"
+        ));
+
+        // Case-insensitive.
+        assert!(!ContainerRuntime::uts_container_mode_from_identity(
+            "docker engine - community"
+        ));
+        assert!(ContainerRuntime::uts_container_mode_from_identity(
+            "PODMAN ENGINE"
+        ));
+
+        // Unrecognised or empty identity keeps the previous behaviour.
+        assert!(ContainerRuntime::uts_container_mode_from_identity(""));
+        assert!(ContainerRuntime::uts_container_mode_from_identity(
+            "Some Other Engine"
+        ));
+    }
+
+    /// Podman ships a Docker-compatible endpoint, so an identity naming both
+    /// must resolve to Podman rather than falling into the Docker branch.
+    #[test]
+    fn test_uts_container_mode_prefers_podman_when_both_named() {
+        assert!(ContainerRuntime::uts_container_mode_from_identity(
+            "Podman Engine (Docker compatible)"
+        ));
+    }
 
     fn make_container(name: &str) -> Container {
         Container {


### PR DESCRIPTION
## Summary

Fixes #88.

When the kubelet falls back to pause-container networking it sets `uts_mode: "container:{pod}_pause"` so app containers inherit the pod hostname. Joining another container's UTS namespace is a **Podman extension** — Docker accepts only `""` or `"host"` for `UtsMode` and rejects container creation outright:

```
Docker API error creating container minimal_c: Docker responded with status code 400: invalid UTS mode: container:minimal_pause
```

So on Docker no pod ever reaches `Running`, and the kubelet retries immediately and forever. One pod logged **54,624** identical failures in a ~30 second window, saturating a CPU core and the Docker API.

UTS is the only namespace Docker won't share this way (Docker 29.6.1):

```console
$ docker run --rm --uts=container:minimal_pause     busybox true
docker: --uts: invalid UTS mode
$ docker run --rm --ipc=container:minimal_pause     busybox true   # ok
$ docker run --rm --pid=container:minimal_pause     busybox true   # ok
$ docker run --rm --network=container:minimal_pause busybox true   # ok
```

### Scope

Only the no-CNI fallback (`using_container_network == true`). With CNI the pod joins `ns:{netns}` and an explicit `hostname` is set instead, so `uts_mode` is already `None`. That fallback is however the default for the single-binary quickstart, where `/opt/cni/bin` is usually absent.

### Why dropping the field is safe

Its purpose is hostname inheritance, and Docker already does that when a container joins another's network namespace:

```console
$ docker run --rm busybox hostname                                  # control
3772591e9b96
$ docker run --rm --network=container:minimal_pause busybox hostname
minimal
```

Setting an explicit `hostname` instead is not an option — Docker rejects that alongside `network_mode: container:` ("conflicting options: hostname and the network mode") — and is unnecessary for the same reason.

### Fix

Probe the daemon once at `ContainerRuntime` construction via `/version` and only set `uts_mode` when the runtime is not positively identified as Docker:

- Podman names itself "Podman Engine" in `Components[].Name`; Docker reports `Platform.Name: "Docker Engine - <edition>"`.
- Matching is case-insensitive, and "podman" wins over "docker" so Podman's Docker-compatible surface can't be misread.
- **Podman behaviour is unchanged**, as is that of any daemon we cannot classify or whose version probe fails — those keep setting `uts_mode` exactly as before. Only a positive Docker match changes anything.

## Test plan

Verified end-to-end against Docker 29.6.1 with the release all-in-one binary, no CNI plugins installed:

- [x] **Before** — pod stuck `Pending`, 54,624 `invalid UTS mode` errors in ~30s
- [x] **After** — startup logs `Container runtime (Docker Engine - Community Engine containerd runc docker-init) does not support uts_mode=container:; pod containers will inherit the pod hostname through the shared network namespace instead`, and:

  ```
  NAME      PHASE     NODE     READY
  minimal   Running   node-1   true
  ```

  with `invalid UTS mode` occurrences: **0**

- [x] **Hostname preserved** — a `busybox` pod named `hosttest` reports `hostname` = `hosttest` inside the app container, i.e. the pod name, not the container ID
- [x] `cargo test -p rusternetes-kubelet` — 176/176 pass (2 new)
- [x] `cargo test --workspace` — 4203 passed, 0 failed (baseline on `main`: 4199; +4 is the 2 new tests across the crate's lib and bin targets)
- [x] `cargo fmt --all -- --check` clean (over workspace members, as `.github/workflows/fmt.yml` does)
- [x] `cargo clippy -p rusternetes-kubelet --all-targets --all-features` — no new warnings (only pre-existing `sort_by_key` at `runtime.rs:7918`)

Podman was not available on this machine, so the Podman path is covered by unit tests over the classification rules rather than a live run — but it is the unchanged branch.

### Tests

`test_uts_container_mode_detection` and `test_uts_container_mode_prefers_podman_when_both_named` cover Docker CE/Enterprise identities, Podman identities, case-insensitivity, the empty/unrecognised fallback, and the "names both" precedence case. The classification is split into a pure `uts_container_mode_from_identity` so it is testable without a live daemon.
