### PR TITLE
fix: give tokio workers an 8 MiB stack so debug builds can sync pods

### DIFF
--- a/crates/common/src/async_runtime.rs
+++ b/crates/common/src/async_runtime.rs
@@ -1,0 +1,85 @@
+//! Tokio runtime configuration shared by the Rusternetes binaries.
+
+/// Stack size to reserve for tokio worker threads, in bytes.
+///
+/// Tokio defaults to 2 MiB per worker thread, which is not enough for the pod
+/// lifecycle path in an unoptimised build. `Kubelet::sync_pod` is a single
+/// `async fn` with over 130 `.await` points, and every awaited sub-future is
+/// stored inline in the generated state machine, so a debug build spills
+/// ~1.6 MiB of that state onto the stack in one frame — with
+/// `ensure_pod_worker` adding ~0.4 MiB beneath it. Together they clear 2 MiB
+/// and the first pod sync hits the guard page, aborting the whole process.
+///
+/// 8 MiB is the value `compose.sqlite.yml` already exports as `RUST_MIN_STACK`
+/// for its kubelet services, and it matches the Linux default for the main
+/// thread (`ulimit -s`). Thread stacks are mapped lazily, so the larger size
+/// costs address space per worker thread rather than resident memory.
+pub const DEFAULT_WORKER_STACK_SIZE: usize = 8 * 1024 * 1024;
+
+// Frame sizes measured under gdb on a debug build: sync_pod took 1,626,304
+// bytes of stack, with ensure_pod_worker adding 438,656 beneath it. The default
+// must stay clear of that, so lowering it fails the build.
+const _: () = assert!(DEFAULT_WORKER_STACK_SIZE > 1_626_304 + 438_656);
+
+/// Stack size to give tokio worker threads.
+///
+/// [`DEFAULT_WORKER_STACK_SIZE`], unless `RUST_MIN_STACK` asks for more.
+/// Passing an explicit size to `thread_stack_size` makes the standard library
+/// stop consulting `RUST_MIN_STACK`, so it is honoured here to keep the
+/// environment variable working as an escape hatch for anyone who needs a
+/// deeper stack than the default provides.
+pub fn worker_stack_size() -> usize {
+    resolve_worker_stack_size(std::env::var("RUST_MIN_STACK").ok().as_deref())
+}
+
+/// Testable core of [`worker_stack_size`].
+///
+/// Takes the `RUST_MIN_STACK` value as an argument instead of reading the
+/// environment, so tests do not have to mutate process-global state. The value
+/// is parsed the way the standard library parses it: anything that is not a
+/// plain integer is ignored.
+fn resolve_worker_stack_size(rust_min_stack: Option<&str>) -> usize {
+    let requested = rust_min_stack
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(0);
+
+    requested.max(DEFAULT_WORKER_STACK_SIZE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_to_eight_mib() {
+        assert_eq!(resolve_worker_stack_size(None), 8 * 1024 * 1024);
+    }
+
+    #[test]
+    fn a_larger_rust_min_stack_wins() {
+        assert_eq!(
+            resolve_worker_stack_size(Some("16777216")),
+            16 * 1024 * 1024
+        );
+    }
+
+    #[test]
+    fn a_smaller_rust_min_stack_does_not_shrink_the_stack() {
+        // 2 MiB is the size that overflows, so it must never be selected.
+        assert_eq!(
+            resolve_worker_stack_size(Some("2097152")),
+            DEFAULT_WORKER_STACK_SIZE
+        );
+    }
+
+    #[test]
+    fn an_unparsable_rust_min_stack_is_ignored() {
+        for value in ["", "8MB", "-1", "8 388 608", "many"] {
+            assert_eq!(
+                resolve_worker_stack_size(Some(value)),
+                DEFAULT_WORKER_STACK_SIZE,
+                "RUST_MIN_STACK={value}"
+            );
+        }
+    }
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod admission;
+pub mod async_runtime;
 pub mod audit;
 pub mod auth;
 pub mod authz;

--- a/crates/kubelet/src/main.rs
+++ b/crates/kubelet/src/main.rs
@@ -88,8 +88,18 @@ struct Args {
     data_dir: String,
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
+    // Built by hand rather than with `#[tokio::main]` so the worker threads get
+    // a stack large enough for the pod sync path — see `worker_stack_size`.
+    // Everything else matches what the macro expands to.
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_stack_size(rusternetes_common::async_runtime::worker_stack_size())
+        .build()?
+        .block_on(run())
+}
+
+async fn run() -> Result<()> {
     let args = Args::parse();
 
     // Load configuration file if specified

--- a/crates/rusternetes/src/main.rs
+++ b/crates/rusternetes/src/main.rs
@@ -113,8 +113,18 @@ struct Args {
     client_ca_file: Option<String>,
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
+    // Built by hand rather than with `#[tokio::main]` so the worker threads get
+    // a stack large enough for the kubelet's pod sync path — see
+    // `worker_stack_size`. Everything else matches what the macro expands to.
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_stack_size(rusternetes_common::async_runtime::worker_stack_size())
+        .build()?
+        .block_on(run())
+}
+
+async fn run() -> Result<()> {
     let args = Args::parse();
 
     let level = match args.log_level.as_str() {


### PR DESCRIPTION
Fixes #90. Rebased onto `main`, on top of @calfonso's `ce4a5e58`, which fixes #95
— the dependency-bump breakage that made the earlier job fail. Without it this
branch cannot compile, which is where those trait errors and warnings came from.

Three commits:

1. `ce4a5e58` (@calfonso) — resolve the build errors from the sha2 0.11, aes-gcm
   0.11, rand 0.10 and prost-types bumps.
2. `461ec000` (@calfonso) — `cargo fmt` on the above.
3. `fix: give tokio workers an 8 MiB stack so debug builds can sync pods` — the
   #90 fix itself, below.

---

## The #90 fix

A debug build of the all-in-one binary aborts as soon as the first pod is
scheduled. The API server, scheduler and controllers are all tokio tasks in the
same process, so the whole cluster goes down with it:

```
INFO rusternetes_scheduler::scheduler: Successfully bound pod to node node-1

thread 'tokio-rt-worker' has overflowed its stack
fatal runtime error: stack overflow, aborting
Aborted (core dumped)
```

### Root cause

Not recursion — the stack is only ~60 frames deep, but two of those frames are
enormous. Differencing stack pointers under gdb:

| frame | bytes | function |
|---|---|---|
| 18 | 4,688 | `rusternetes_kubelet::runtime::is_pod_running` |
| 20 | **1,626,304** | `rusternetes_kubelet::kubelet::sync_pod` |
| 22 | **438,656** | `rusternetes_kubelet::kubelet::ensure_pod_worker` |

`Kubelet::sync_pod` is a single 2,369-line `async fn` with 133 `.await` points.
Every awaited sub-future is stored inline in the enclosing state machine, and an
unoptimised build spills that state onto the stack — 1.6 MiB in one frame, with
`ensure_pod_worker` adding 0.4 MiB beneath it. Together they clear tokio's 2 MiB
default worker stack and the first sync walks into the guard page.

### The change

`#[tokio::main]` expands to `Builder::new_multi_thread().enable_all().build()`
with no stack configuration. The two binaries that run the pod lifecycle — the
all-in-one and the standalone kubelet — now build that runtime by hand and add
`.thread_stack_size(...)`. Nothing else about the expansion changes; the async
body moves verbatim into `run()`.

The size lives in one place, `rusternetes_common::async_runtime`:

- **8 MiB by default.** That is the value `compose.sqlite.yml` and
  `docker-compose.sqlite.yml` already export as `RUST_MIN_STACK` for their
  kubelet services, and it matches the Linux default for the main thread
  (`ulimit -s`). Thread stacks are mapped lazily, so this costs address space per
  worker thread rather than resident memory. Release builds do not overflow
  either way; they simply get the same headroom.
- **`RUST_MIN_STACK` still wins when it asks for more.** Passing an explicit size
  to `thread_stack_size` makes the standard library stop consulting that
  variable, which would have quietly broken the workaround documented in #90.
  Taking whichever is larger keeps it usable as an escape hatch, and stops a
  smaller value from reintroducing the crash.

### What this does not fix

This mitigates rather than cures. The real fix is shrinking the `sync_pod` state
machine — boxing its larger awaited sub-futures, or splitting the 2,369-line
function up — which is a refactor of the pod lifecycle path and wants its own PR.
Happy to pick that up separately if you'd like it.

Deliberately left alone: the other five binaries keep `#[tokio::main]` (none runs
the pod lifecycle, so none has a frame near this size), and the now-redundant
`RUST_MIN_STACK=8388608` lines in the two sqlite compose files.

---

## Testing

Reproduction from #90 on the rebased branch — all-in-one with SQLite, one bare
`pause:3.9` pod, `RUST_MIN_STACK` unset:

|  | before | after |
|---|---|---|
| process | **aborts 3s after pod create** | alive after 45s |
| `stack overflow` markers in log | 2 | 0 |
| pod phase | — (process gone) | `Running` |

Re-run with `RUST_MIN_STACK=2097152` — the 2 MiB size that overflows — to confirm
the explicit size is what is in effect and that a smaller value cannot shrink it
back: process alive, 0 markers, pod `Running`.

The standalone `kubelet` binary was started through the same new `main` → `run()`
path and reaches node registration normally (it then fails on the unreachable
etcd endpoint it was pointed at, as expected).

Pre-commit, on this branch:

- `cargo fmt` — clean (workspace members only, as the fmt workflow does).
- `cargo test --workspace --locked` — **4,217 passed, 0 failed, 22 ignored**
  across 140 suites.
- `cargo clippy --workspace --all-targets --locked` (the command CI runs) —
  exit 0, and **no warnings in any file this branch touches**. The four warnings
  the failed job printed were the `unused import` and `deprecated trait`
  diagnostics on `aes_gcm::aead::rand_core::RngCore`; the aes-gcm fix deletes
  those lines, so they are gone with the errors.
  The nine warning sites that remain are pre-existing on `main` and untouched
  here (`collapsible_if`, `sort_by_key`); I left them alone to keep this diff to
  the point, but say the word and I will clean them up in a follow-up.
