### PR TITLE
fix(kubelet): resolve config env through an injectable lookup in tests

### DIFF
--- a/crates/kubelet/src/config.rs
+++ b/crates/kubelet/src/config.rs
@@ -246,11 +246,47 @@ impl RuntimeConfig {
         node_name: String,
         etcd_endpoints: Vec<String>,
     ) -> Result<Self> {
+        Self::build_with_env(
+            cli_root_dir,
+            cli_volume_dir,
+            cli_volume_plugin_dir,
+            cli_sync_frequency,
+            cli_metrics_port,
+            cli_log_level,
+            config_file,
+            node_name,
+            etcd_endpoints,
+            |key| std::env::var(key).ok(),
+        )
+    }
+
+    /// Testable core of [`RuntimeConfig::build`].
+    ///
+    /// Takes the environment lookup as an argument instead of reading the
+    /// process environment, so a test can exercise the config-file and default
+    /// tiers without depending on the developer's shell. The environment tier
+    /// sits above the defaults, so reading the real environment makes any
+    /// assertion about a default fail once the corresponding variable is
+    /// exported — and this repo's own workflow exports `KUBELET_VOLUMES_PATH`.
+    /// Same rationale as `rusternetes_common::async_runtime`.
+    #[allow(clippy::too_many_arguments)]
+    fn build_with_env(
+        cli_root_dir: Option<String>,
+        cli_volume_dir: Option<String>,
+        cli_volume_plugin_dir: Option<String>,
+        cli_sync_frequency: Option<u64>,
+        cli_metrics_port: Option<u16>,
+        cli_log_level: Option<String>,
+        config_file: Option<KubeletConfiguration>,
+        node_name: String,
+        etcd_endpoints: Vec<String>,
+        mut get_env: impl FnMut(&str) -> Option<String>,
+    ) -> Result<Self> {
         // Determine root directory
         // Precedence: CLI > Config > Env > Default
         let root_dir = cli_root_dir
             .or_else(|| config_file.as_ref().and_then(|c| c.root_dir.clone()))
-            .or_else(|| std::env::var("KUBELET_ROOT_DIR").ok())
+            .or_else(|| get_env("KUBELET_ROOT_DIR"))
             .unwrap_or_else(|| {
                 // For development: use current dir, for production: /var/lib/kubelet
                 std::env::current_dir()
@@ -263,7 +299,7 @@ impl RuntimeConfig {
         // Precedence: CLI > Config > Env > Root-dir-based default
         let volume_dir = cli_volume_dir
             .or_else(|| config_file.as_ref().and_then(|c| c.volume_dir.clone()))
-            .or_else(|| std::env::var("KUBELET_VOLUMES_PATH").ok())
+            .or_else(|| get_env("KUBELET_VOLUMES_PATH"))
             .unwrap_or_else(|| format!("{}/volumes", root_dir));
 
         // Determine volume plugin directory
@@ -273,7 +309,7 @@ impl RuntimeConfig {
                     .as_ref()
                     .and_then(|c| c.volume_plugin_dir.clone())
             })
-            .or_else(|| std::env::var("KUBELET_VOLUME_PLUGIN_DIR").ok())
+            .or_else(|| get_env("KUBELET_VOLUME_PLUGIN_DIR"))
             .unwrap_or_else(|| "/usr/libexec/kubernetes/kubelet-plugins/volume/exec".to_string());
 
         // Determine sync frequency
@@ -289,7 +325,7 @@ impl RuntimeConfig {
         // Determine log level
         let log_level = cli_log_level
             .or_else(|| config_file.as_ref().and_then(|c| c.log_level.clone()))
-            .or_else(|| std::env::var("RUST_LOG").ok())
+            .or_else(|| get_env("RUST_LOG"))
             .unwrap_or_else(|| "info".to_string());
 
         // Determine cluster service CIDR and extract kubernetes service host IP
@@ -297,15 +333,15 @@ impl RuntimeConfig {
         let cluster_service_cidr = config_file
             .as_ref()
             .and_then(|c| c.cluster_service_cidr.clone())
-            .or_else(|| std::env::var("CLUSTER_SERVICE_CIDR").ok())
+            .or_else(|| get_env("CLUSTER_SERVICE_CIDR"))
             .unwrap_or_else(|| "10.96.0.0/12".to_string());
 
         // Use KUBERNETES_SERVICE_HOST_OVERRIDE if set — this allows the API server
         // address to be configured for environments where ClusterIP routing doesn't
         // work from pod containers (e.g., Podman Machine without br_netfilter).
         // Falls back to the kubernetes service ClusterIP (10.96.0.1).
-        let kubernetes_service_host = std::env::var("KUBERNETES_SERVICE_HOST_OVERRIDE")
-            .unwrap_or_else(|_| {
+        let kubernetes_service_host =
+            get_env("KUBERNETES_SERVICE_HOST_OVERRIDE").unwrap_or_else(|| {
                 first_ip_from_cidr(&cluster_service_cidr)
                     .unwrap_or_else(|_| "10.96.0.1".to_string())
             });
@@ -511,7 +547,10 @@ mod tests {
 
     #[test]
     fn test_runtime_config_defaults() {
-        let runtime = RuntimeConfig::build(
+        // Empty environment: the env tier outranks the defaults asserted here,
+        // so reading the real one would fail this test for anyone who exports
+        // RUST_LOG or KUBELET_VOLUMES_PATH.
+        let runtime = RuntimeConfig::build_with_env(
             None,
             None,
             None,
@@ -521,6 +560,7 @@ mod tests {
             None,
             "test-node".to_string(),
             vec!["http://localhost:2379".to_string()],
+            |_| None,
         )
         .unwrap();
 
@@ -528,6 +568,35 @@ mod tests {
         assert_eq!(runtime.metrics_bind_port, 8082);
         assert_eq!(runtime.log_level, "info");
         assert!(runtime.volume_dir.ends_with("volumes"));
+    }
+
+    #[test]
+    fn test_runtime_config_env_tier_outranks_defaults() {
+        // The tier the test above has to be insulated from: with no CLI flag and
+        // no config file, an exported value wins over the default.
+        let runtime = RuntimeConfig::build_with_env(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            "test-node".to_string(),
+            vec!["http://localhost:2379".to_string()],
+            |key| match key {
+                "RUST_LOG" => Some("debug".to_string()),
+                "KUBELET_VOLUMES_PATH" => Some("/tmp/rusternetes-test-volume-dir".to_string()),
+                _ => None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(runtime.log_level, "debug");
+        assert_eq!(
+            runtime.volume_dir,
+            PathBuf::from("/tmp/rusternetes-test-volume-dir")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #96. `config::tests::test_runtime_config_defaults` asserts the kubelet's
*default* config values, but `RuntimeConfig::build` reads the process environment
and the environment tier outranks the defaults — so the test failed for anyone
with one of those variables exported:

```
$ RUST_LOG=debug cargo test -p rusternetes-kubelet
assertion `left == right` failed
  left: "debug"
 right: "info"

$ KUBELET_VOLUMES_PATH=/var/lib/kubelet/vols cargo test -p rusternetes-kubelet
assertion failed: runtime.volume_dir.ends_with("volumes")
```

This is the documented workflow. `make dev-up` refuses to run without the
variable and prints the fix itself:

```
ERROR: KUBELET_VOLUMES_PATH environment variable is not set!
  export KUBELET_VOLUMES_PATH=$(pwd)/.rusternetes/volumes
```

The suggested value survived only by coincidence — the assertion is
`ends_with("volumes")` and that path ends in `volumes`:

| exported | before | after |
| --- | --- | --- |
| `KUBELET_VOLUMES_PATH=$(pwd)/.rusternetes/volumes` | passes (coincides) | passes |
| `KUBELET_VOLUMES_PATH=/var/lib/kubelet/vols` | **fails** | passes |
| `RUST_LOG=info` | passes (coincides) | passes |
| `RUST_LOG=debug` | **fails** | passes |

So the test passed only when the exported value happened to match what it
asserts. CI never caught it because the runner has none of these set.

## Approach

The precedence — CLI > config > env > default — is the documented contract and is
**unchanged**. What was missing is a way for a test to reach the default tier.

This repo already has the seam. `crates/common/src/async_runtime.rs`:

```rust
/// Testable core of [`worker_stack_size`].
///
/// Takes the `RUST_MIN_STACK` value as an argument instead of reading the
/// environment, so tests do not have to mutate process-global state.
fn resolve_worker_stack_size(rust_min_stack: Option<&str>) -> usize { ... }
```

So `build` stays as the wrapper that reads the real environment, and its body
moves to `build_with_env`, taking `impl FnMut(&str) -> Option<String>`. All six
env reads route through it.

- The defaults test injects an empty environment.
- `test_runtime_config_precedence` and `test_runtime_config_validation` keep
  calling `build`, so the public wrapper stays covered.
- The one non-test call site, `crates/kubelet/src/main.rs:121`, is untouched and
  behaviour is identical.

New `test_runtime_config_env_tier_outranks_defaults` pins env-over-default
deliberately, rather than leaving it as the tier another test has to dodge.

## Validation

No cluster, no container runtime — plain `cargo test`.

- `cargo test --workspace`, clean environment: **140 suites, 4219 tests, 0 failed**
- `cargo test --workspace` with `RUST_LOG=debug KUBELET_VOLUMES_PATH=/tmp/rn-vols`: **140 suites, 4219 tests, 0 failed**
- Each of `RUST_LOG`, `KUBELET_VOLUMES_PATH`, `KUBELET_ROOT_DIR`,
  `KUBELET_VOLUME_PLUGIN_DIR`, `CLUSTER_SERVICE_CIDR`,
  `KUBERNETES_SERVICE_HOST_OVERRIDE` exported individually: green
- `cargo fmt --all -- --check`: clean

On clippy: `make pre-commit` runs `cargo clippy --all-targets --all-features -- -D warnings`,
which cannot pass on `main` as it stands, so I used CI's command
(`cargo clippy --workspace --all-targets --locked`) and checked my own file. It
reports no warnings in `crates/kubelet/src/config.rs`; the two it does report
(`rusternetes-common` collapsible-`if`, `rusternetes-kubelet` `sort_by_key`) are
pre-existing and elsewhere.

## Deliberately not fixed

`crates/cloud-providers/src/lib.rs` mutates process-global state in its tests
(`std::env::set_var` / `remove_var` on `CLOUD_PROVIDER`, `AWS_REGION`, and
others). Those tests are `#[serial]` and I could not make them fail —
`CLOUD_PROVIDER=aws` and `AWS_REGION=us-east-1` both leave the suite green — so I
left them alone rather than churn passing code. Flagging it only because
`#[serial]` orders serial tests against each other, not against the rest of the
binary. Happy to fold it in if you want it in the same PR.
