### PR TITLE
fix(api-server): apply negated field selectors on watch endpoints

### DIFF
--- a/crates/api-server/src/handlers/watch.rs
+++ b/crates/api-server/src/handlers/watch.rs
@@ -1214,20 +1214,28 @@ fn matches_field_selector(metadata: &ObjectMeta, selector: &Option<String>) -> b
 
     for requirement in selector.split(',') {
         let requirement = requirement.trim();
-        if let Some((field, value)) = requirement.split_once('=') {
-            match field {
-                "metadata.name" => {
-                    if metadata.name != value {
-                        return false;
-                    }
-                }
-                "metadata.namespace" => {
-                    if metadata.namespace.as_deref() != Some(value) {
-                        return false;
-                    }
-                }
-                _ => {} // Unknown fields pass through
-            }
+
+        // `!=` has to be probed before `=`. `split_once('=')` splits inside the
+        // `!=`, which leaves the field name with a trailing `!` ("metadata.name!"),
+        // and an unrecognised field is passed through — so a negated requirement
+        // would be dropped instead of applied.
+        let (field, value, negated) = match requirement.split_once("!=") {
+            Some((field, value)) => (field.trim(), value.trim(), true),
+            None => match requirement.split_once('=') {
+                Some((field, value)) => (field.trim(), value.trim(), false),
+                None => continue,
+            },
+        };
+
+        let equal = match field {
+            "metadata.name" => metadata.name == value,
+            "metadata.namespace" => metadata.namespace.as_deref() == Some(value),
+            _ => continue, // Unknown fields pass through
+        };
+
+        // `=` keeps only equal objects, `!=` keeps only unequal ones.
+        if equal == negated {
+            return false;
         }
     }
     true
@@ -2617,4 +2625,116 @@ pub async fn watch_namespaced_json(
         .header(header::TRANSFER_ENCODING, "chunked")
         .body(body)
         .unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn meta(name: &str, namespace: Option<&str>) -> ObjectMeta {
+        let meta = ObjectMeta::new(name);
+        match namespace {
+            Some(ns) => meta.with_namespace(ns),
+            None => meta,
+        }
+    }
+
+    #[test]
+    fn field_selector_absent_or_empty_matches_everything() {
+        let m = meta("pod-a", Some("default"));
+        assert!(matches_field_selector(&m, &None));
+        assert!(matches_field_selector(&m, &Some(String::new())));
+    }
+
+    #[test]
+    fn field_selector_equality_filters_name_and_namespace() {
+        let m = meta("pod-a", Some("default"));
+
+        assert!(matches_field_selector(
+            &m,
+            &Some("metadata.name=pod-a".to_string())
+        ));
+        assert!(!matches_field_selector(
+            &m,
+            &Some("metadata.name=pod-b".to_string())
+        ));
+        assert!(matches_field_selector(
+            &m,
+            &Some("metadata.namespace=default".to_string())
+        ));
+        assert!(!matches_field_selector(
+            &m,
+            &Some("metadata.namespace=kube-system".to_string())
+        ));
+    }
+
+    #[test]
+    fn field_selector_honours_negated_requirements() {
+        let m = meta("pod-a", Some("default"));
+
+        // `split_once('=')` used to split inside the `!=`, leaving the field name
+        // as "metadata.name!" -- an unrecognised field, so the requirement was
+        // dropped and the object matched regardless of the value.
+        assert!(!matches_field_selector(
+            &m,
+            &Some("metadata.name!=pod-a".to_string())
+        ));
+        assert!(matches_field_selector(
+            &m,
+            &Some("metadata.name!=pod-b".to_string())
+        ));
+        assert!(!matches_field_selector(
+            &m,
+            &Some("metadata.namespace!=default".to_string())
+        ));
+        assert!(matches_field_selector(
+            &m,
+            &Some("metadata.namespace!=kube-system".to_string())
+        ));
+    }
+
+    #[test]
+    fn field_selector_combines_requirements_with_and() {
+        let m = meta("pod-a", Some("default"));
+
+        assert!(matches_field_selector(
+            &m,
+            &Some("metadata.namespace=default,metadata.name!=pod-b".to_string())
+        ));
+        // The second requirement excludes it even though the first matches.
+        assert!(!matches_field_selector(
+            &m,
+            &Some("metadata.namespace=default,metadata.name!=pod-a".to_string())
+        ));
+    }
+
+    #[test]
+    fn field_selector_passes_through_unsupported_fields() {
+        // Only metadata.name / metadata.namespace are evaluated here; anything
+        // else is deliberately not filtered, in either polarity.
+        let m = meta("pod-a", Some("default"));
+        assert!(matches_field_selector(
+            &m,
+            &Some("spec.nodeName=node-1".to_string())
+        ));
+        assert!(matches_field_selector(
+            &m,
+            &Some("spec.nodeName!=node-1".to_string())
+        ));
+    }
+
+    #[test]
+    fn field_selector_namespace_requirement_excludes_cluster_scoped_objects() {
+        // Unchanged from before: an object with no namespace never satisfies a
+        // metadata.namespace equality requirement.
+        let m = meta("node-1", None);
+        assert!(!matches_field_selector(
+            &m,
+            &Some("metadata.namespace=default".to_string())
+        ));
+        assert!(matches_field_selector(
+            &m,
+            &Some("metadata.namespace!=default".to_string())
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #98. Watch endpoints silently ignored negated field selectors.
`matches_field_selector` split each requirement with `split_once('=')`, which
splits *inside* a `!=` and leaves the field name with a trailing `!`. That name
matched no arm of the `match`, so it fell into the pass-through arm and the
requirement was dropped:

```
fieldSelector=metadata.name!=pod-a
  -> field = "metadata.name!", value = "pod-a"   -> ignored
```

So a watch streamed the very objects the client asked to exclude. The positive
form worked, which made the failure silent and asymmetric — `=` filtered, `!=`
did not, and a client could not distinguish "nothing was excluded" from "the
exclusion was ignored".

The helper is called from **8 sites** in `watch.rs`, covering both the
initial-list and the streaming phases of every watch handler, so this affected
all watched resource types.

## Change

Probe `!=` before `=`, then apply the requirement with the right polarity. The
sibling parser in `crates/common/src/field_selector.rs` already orders the
operators this way (`!=`, then `==`, then `=`); only this watch-local copy did
not.

The equality comparisons are carried over unchanged, so the working `=` path
keeps its exact semantics — including that `metadata.namespace=<ns>` still
excludes cluster-scoped objects, which have no namespace.

## Validation

No cluster and no container runtime — plain `cargo test`.

Six new tests in `handlers::watch::tests`. The split is deliberate:

| test | before | after |
| --- | --- | --- |
| `field_selector_honours_negated_requirements` | **fails** | passes |
| `field_selector_combines_requirements_with_and` | **fails** | passes |
| `field_selector_equality_filters_name_and_namespace` | passes | passes |
| `field_selector_absent_or_empty_matches_everything` | passes | passes |
| `field_selector_passes_through_unsupported_fields` | passes | passes |
| `field_selector_namespace_requirement_excludes_cluster_scoped_objects` | passes | passes |

I verified that by reverting just the production hunk with the tests in place: the
two negation tests fail, the other four pass. That is what establishes both that
the bug is real and that the `=` path is untouched.

- `cargo test --workspace`: **140 suites, 4229 tests, 0 failed**
- `cargo fmt --all -- --check`: clean

On clippy: `make pre-commit` runs `cargo clippy --all-targets --all-features -- -D warnings`,
which cannot pass on `main` as it stands, so I used CI's command and checked my
own file. No warnings in `crates/api-server/src/handlers/watch.rs`. The rewrite
also happens to remove one pre-existing `collapsible_match` warning (the old
`metadata.namespace` arm), taking the workspace count from 9 to 8.

## Relationship to #97

Independent, and based on `main`. #97 touches only
`crates/kubelet/src/config.rs`; this touches only
`crates/api-server/src/handlers/watch.rs`. I test-merged both orders: each
auto-merges cleanly and the resulting trees are byte-identical, with both test
areas green in the combined state. Merge them in either order.

## Deliberately not fixed

1. **Unsupported fields still pass through.** `matches_field_selector` receives
   only `&ObjectMeta`, so it structurally cannot evaluate `spec.nodeName` or
   `status.phase`; those requirements are ignored rather than applied. Real
   Kubernetes rejects an unsupported field selector with a 400. Silently
   returning everything is arguably worse, but fixing it means either handing the
   function the whole object or failing the request — a behaviour change that
   deserves its own discussion.
2. **The duplicate implementation.** `crates/common/src/field_selector.rs` is a
   fuller parser. Consolidating the watch path onto it would remove this class of
   divergence, but is a larger refactor.

Glad to do either as a follow-up.
