### PR TITLE
fix(controller-manager): round Deployment maxUnavailable down

### DIFF
--- a/crates/controller-manager/src/controllers/deployment.rs
+++ b/crates/controller-manager/src/controllers/deployment.rs
@@ -11,11 +11,23 @@ use std::{sync::Arc, time::Duration};
 use tracing::{debug, error, info, warn};
 
 /// Parse a value that can be either an absolute integer or a percentage string (e.g. "25%" or "1").
-/// For percentages, the result is ceil(pct/100 * total). Defaults to 1 if unparseable.
-fn parse_int_or_percent(s: &str, total: i32) -> i32 {
+///
+/// `round_up` selects the rounding direction for percentages, mirroring
+/// `intstr.GetScaledValueFromIntOrPercent(value, total, roundUp)`. The two
+/// rolling-update fenceposts round in opposite directions, so the caller has to
+/// say which one it is asking for.
+///
+/// Defaults to 1 for an unparseable absolute value and to 25% for an
+/// unparseable percentage.
+fn parse_int_or_percent(s: &str, total: i32, round_up: bool) -> i32 {
     if s.ends_with('%') {
         let pct: f64 = s.trim_end_matches('%').parse().unwrap_or(25.0);
-        ((pct / 100.0) * total as f64).ceil() as i32
+        let scaled = (pct / 100.0) * total as f64;
+        if round_up {
+            scaled.ceil() as i32
+        } else {
+            scaled.floor() as i32
+        }
     } else {
         s.parse().unwrap_or(1)
     }
@@ -23,13 +35,30 @@ fn parse_int_or_percent(s: &str, total: i32) -> i32 {
 
 /// Compute the max surge and max unavailable counts for a rolling update.
 /// Returns (max_surge, max_unavailable).
+///
+/// K8s ref: pkg/controller/deployment/util/deployment_util.go — ResolveFenceposts.
+/// `maxSurge` is rounded up and `maxUnavailable` down, per
+/// `k8s.io/api/apps/v1` RollingUpdateDeployment: "Absolute number is calculated
+/// from percentage by rounding up" for surge and "by rounding down" for
+/// unavailable. Rounding unavailable up would let a rollout take down more pods
+/// than the spec permits, since the caller derives
+/// `min_available = desired - max_unavailable`.
+///
+/// Rounding down can legitimately produce 0. If surge is also 0 the rollout
+/// could neither add nor remove a pod, so unavailable is forced to 1 to keep it
+/// from stalling — the same fallback, for the same reason, as upstream.
 fn compute_rolling_update_counts(
     desired: i32,
     max_surge: &str,
     max_unavailable: &str,
 ) -> (i32, i32) {
-    let surge = parse_int_or_percent(max_surge, desired);
-    let unavailable = parse_int_or_percent(max_unavailable, desired);
+    let surge = parse_int_or_percent(max_surge, desired, true);
+    let mut unavailable = parse_int_or_percent(max_unavailable, desired, false);
+
+    if surge == 0 && unavailable == 0 {
+        unavailable = 1;
+    }
+
     (surge, unavailable)
 }
 
@@ -1176,7 +1205,7 @@ impl<S: Storage + 'static> DeploymentController<S> {
                     })
                 })
                 .unwrap_or_else(|| "25%".to_string());
-            let surge = parse_int_or_percent(&local_max_surge, desired);
+            let surge = parse_int_or_percent(&local_max_surge, desired, true);
             annotations.insert(
                 "deployment.kubernetes.io/desired-replicas".to_string(),
                 desired.to_string(),
@@ -1962,38 +1991,53 @@ mod tests {
 
     #[test]
     fn test_parse_int_or_percent_percentage() {
-        assert_eq!(parse_int_or_percent("25%", 10), 3); // ceil(2.5) = 3
-        assert_eq!(parse_int_or_percent("50%", 10), 5);
-        assert_eq!(parse_int_or_percent("100%", 10), 10);
-        assert_eq!(parse_int_or_percent("25%", 4), 1); // ceil(1.0) = 1
-        assert_eq!(parse_int_or_percent("25%", 1), 1); // ceil(0.25) = 1
+        assert_eq!(parse_int_or_percent("25%", 10, true), 3); // ceil(2.5) = 3
+        assert_eq!(parse_int_or_percent("50%", 10, true), 5);
+        assert_eq!(parse_int_or_percent("100%", 10, true), 10);
+        assert_eq!(parse_int_or_percent("25%", 4, true), 1); // ceil(1.0) = 1
+        assert_eq!(parse_int_or_percent("25%", 1, true), 1); // ceil(0.25) = 1
+    }
+
+    #[test]
+    fn test_parse_int_or_percent_percentage_rounding_down() {
+        assert_eq!(parse_int_or_percent("25%", 10, false), 2); // floor(2.5) = 2
+        assert_eq!(parse_int_or_percent("50%", 10, false), 5); // exact, unaffected
+        assert_eq!(parse_int_or_percent("100%", 10, false), 10);
+        assert_eq!(parse_int_or_percent("25%", 4, false), 1); // floor(1.0) = 1
+        assert_eq!(parse_int_or_percent("25%", 1, false), 0); // floor(0.25) = 0
     }
 
     #[test]
     fn test_parse_int_or_percent_absolute() {
-        assert_eq!(parse_int_or_percent("1", 10), 1);
-        assert_eq!(parse_int_or_percent("3", 10), 3);
-        assert_eq!(parse_int_or_percent("0", 10), 0);
+        // Absolute values are exact, so the rounding direction cannot matter.
+        for round_up in [true, false] {
+            assert_eq!(parse_int_or_percent("1", 10, round_up), 1);
+            assert_eq!(parse_int_or_percent("3", 10, round_up), 3);
+            assert_eq!(parse_int_or_percent("0", 10, round_up), 0);
+        }
     }
 
     #[test]
     fn test_parse_int_or_percent_invalid() {
         // Invalid strings default to 1
-        assert_eq!(parse_int_or_percent("abc", 10), 1);
-        assert_eq!(parse_int_or_percent("", 10), 1);
+        for round_up in [true, false] {
+            assert_eq!(parse_int_or_percent("abc", 10, round_up), 1);
+            assert_eq!(parse_int_or_percent("", 10, round_up), 1);
+        }
     }
 
     #[test]
     fn test_parse_int_or_percent_invalid_percentage() {
-        // Invalid percentage defaults to 25%
-        assert_eq!(parse_int_or_percent("abc%", 10), 3); // ceil(25% of 10) = 3
+        // Invalid percentage defaults to 25%, then rounds as asked.
+        assert_eq!(parse_int_or_percent("abc%", 10, true), 3); // ceil(2.5) = 3
+        assert_eq!(parse_int_or_percent("abc%", 10, false), 2); // floor(2.5) = 2
     }
 
     #[test]
     fn test_compute_rolling_update_counts_defaults() {
         let (surge, unavailable) = compute_rolling_update_counts(10, "25%", "25%");
         assert_eq!(surge, 3); // ceil(2.5) = 3
-        assert_eq!(unavailable, 3);
+        assert_eq!(unavailable, 2); // floor(2.5) = 2
     }
 
     #[test]
@@ -2012,10 +2056,44 @@ mod tests {
 
     #[test]
     fn test_compute_rolling_update_counts_small_deployment() {
-        // For a deployment with 1 replica, 25% rounds up to 1
+        // 1 replica with the default strategy: surge to 2, and keep the single
+        // pod available while the replacement comes up.
         let (surge, unavailable) = compute_rolling_update_counts(1, "25%", "25%");
-        assert_eq!(surge, 1);
-        assert_eq!(unavailable, 1);
+        assert_eq!(surge, 1); // ceil(0.25) = 1
+        assert_eq!(unavailable, 0); // floor(0.25) = 0
+    }
+
+    #[test]
+    fn test_compute_rolling_update_counts_forces_progress_when_both_zero() {
+        // Rounding maxUnavailable down can reach 0. With no surge either, the
+        // rollout could not add or remove a pod, so unavailable becomes 1.
+        assert_eq!(compute_rolling_update_counts(1, "0", "25%"), (0, 1));
+        assert_eq!(compute_rolling_update_counts(3, "0%", "30%"), (0, 1));
+        assert_eq!(compute_rolling_update_counts(10, "0", "0"), (0, 1));
+
+        // A surge of at least 1 already allows progress, so 0 unavailable stands.
+        assert_eq!(compute_rolling_update_counts(1, "1", "25%"), (1, 0));
+    }
+
+    #[test]
+    fn test_compute_rolling_update_counts_never_exceeds_requested_unavailability() {
+        // The caller derives min_available = desired - max_unavailable, so
+        // max_unavailable must never exceed the percentage the spec asked for.
+        for desired in 1..=64 {
+            for pct in ["10%", "25%", "33%", "50%", "75%"] {
+                let (surge, unavailable) = compute_rolling_update_counts(desired, "25%", pct);
+                let requested = pct.trim_end_matches('%').parse::<f64>().unwrap() / 100.0;
+                let allowed = (desired as f64 * requested).floor() as i32;
+
+                // The both-zero fallback is the one documented exception, and it
+                // needs surge to be 0 — which "25%" never is for desired >= 1.
+                assert!(surge >= 1, "desired={desired}");
+                assert!(
+                    unavailable <= allowed,
+                    "desired={desired} maxUnavailable={pct}: got {unavailable}, spec allows {allowed}"
+                );
+            }
+        }
     }
 
     /// Helper to create a minimal Container for tests


### PR DESCRIPTION
## Summary

Fixes #100. `compute_rolling_update_counts` resolved both rolling-update
fenceposts through `parse_int_or_percent`, which always rounded percentages up.
That is correct for `maxSurge` and wrong for `maxUnavailable` — the two round in
opposite directions (`k8s.io/api/apps/v1`, RollingUpdateDeployment: surge
"calculated from percentage by rounding up", unavailable "by rounding down").

The rolling-update path turns that number into the availability floor in three
places, each `let min_available = (desired_replicas - max_unavailable).max(0);`
— `rolloutRolling` (`deployment.rs:641`), `reconcileOldReplicaSets` (`:762`) and
the newly-created-RS branch (`:863`). Two of them carry comments saying they are
there to "maintain the minimum availability guarantee". Rounding up lowered it:

| `spec.replicas` | maxUnavailable at 25% | `min_available` before | per the spec |
| --- | --- | --- | --- |
| 1 | ceil(0.25) = **1** | **0** | 1 |
| 5 | ceil(1.25) = **2** | **3** | 4 |
| 6 | ceil(1.5) = **2** | **4** | 5 |
| 10 | ceil(2.5) = **3** | **7** | 8 |

A single-replica deployment is the sharpest case: `min_available` became 0, so
the only pod could be removed before its replacement was ready. With the correct
rounding `maxUnavailable` is 0 and the rollout surges instead — `maxSurge` is
ceil(0.25) = 1, so the replacement comes up first and there is no gap.

Both fenceposts default to `"25%"` when `spec.strategy` is unset
(`deployment.rs:517-529`), so this reached any deployment that had not set them
explicitly and whose replica count times the percentage was not a whole number.

## Change

`parse_int_or_percent` takes an explicit `round_up` argument, mirroring
`intstr.GetScaledValueFromIntOrPercent(value, total, roundUp)`. `maxSurge` passes
`true`, `maxUnavailable` passes `false`. The other call site derives the
`max-replicas` annotation from `maxSurge` and keeps `true`, so it is unchanged;
so are the absolute-value and unparseable-input fallbacks, which do not depend on
rounding.

Rounding down can now yield 0, which upstream's `ResolveFenceposts` guards
against: with both fenceposts at 0 a rollout can neither add nor remove a pod, so
`maxUnavailable` is forced to 1. That state is reachable here — `maxSurge: 0`
with `maxUnavailable: 25%` on 1 replica resolves to (0, 0) — so the fallback
lands with the rounding change rather than as a follow-up.

`resolve_max_unavailable` in `daemonset.rs:1256` is left alone. DaemonSet's
`maxUnavailable` does round up per its own API docs, and that function already
documents the direction and clamps to 1.

## Validation

No cluster and no container runtime — plain `cargo test`.

Two existing tests pinned the old rounding and are updated; three are added:

| test | before | after |
| --- | --- | --- |
| `test_compute_rolling_update_counts_defaults` (3 → 2 unavailable of 10) | **fails** | passes |
| `test_compute_rolling_update_counts_small_deployment` (1 → 0 unavailable of 1) | **fails** | passes |
| `test_compute_rolling_update_counts_forces_progress_when_both_zero` | **fails** | passes |
| `test_compute_rolling_update_counts_never_exceeds_requested_unavailability` | **fails** | passes |
| `test_parse_int_or_percent_percentage_rounding_down` | passes | passes |
| `test_parse_int_or_percent_percentage` (surge direction) | passes | passes |
| `test_parse_int_or_percent_absolute` / `_invalid` / `_invalid_percentage` | passes | passes |
| `test_compute_rolling_update_counts_absolute` / `_mixed` | passes | passes |

The last of the three new tests sweeps 1..=64 replicas against `10%`, `25%`,
`33%`, `50%` and `75%`, asserting `max_unavailable` never exceeds
`floor(replicas × pct)`.

I verified the split by reverting just the production hunk with the tests in
place — exactly those four fail and the other sixteen pass, including every
`parse_int_or_percent` surge case and all the rollout and proportional-scaling
tests:

```
result: FAILED. 16 passed; 4 failed
desired=1 maxUnavailable=10%: got 1, spec allows 0
assertion `left == right` failed
  left: (0, 0)
 right: (0, 1)
```

- `cargo test --workspace --locked`: **140 suites, 4237 tests, 0 failed**
- `cargo fmt` (workspace members, as the fmt workflow runs it): clean
- `cargo clippy --workspace --all-targets --locked`: no warnings in
  `crates/controller-manager/src/controllers/deployment.rs`
