### PR TITLE
fix(controller-manager): clamp PodDisruptionBudget status counts at zero

### DIFF
--- a/crates/controller-manager/src/controllers/pod_disruption_budget.rs
+++ b/crates/controller-manager/src/controllers/pod_disruption_budget.rs
@@ -171,8 +171,22 @@ impl<S: Storage + 'static> PodDisruptionBudgetController<S> {
         let desired_healthy = self.calculate_desired_healthy(pdb, total_pods)?;
 
         // 5. Calculate disruptions_allowed
-        // disruptions_allowed = current_healthy - desired_healthy
-        let disruptions_allowed = healthy_pods - desired_healthy;
+        //
+        // A budget that is already breached allows no further disruption; it does
+        // not allow a negative number of them. Consumers read this as a count —
+        // the eviction handler in `pod_subresources` denies eviction on any value
+        // <= 0, and users see it as ALLOWED DISRUPTIONS.
+        //
+        // K8s ref: pkg/controller/disruption/disruption.go — updatePdbStatus:
+        //   disruptionsAllowed := currentHealthy - desiredHealthy
+        //   if expectedCount <= 0 || disruptionsAllowed <= 0 {
+        //       disruptionsAllowed = 0
+        //   }
+        let disruptions_allowed = if total_pods <= 0 {
+            0
+        } else {
+            (healthy_pods - desired_healthy).max(0)
+        };
 
         debug!(
             "PDB {}/{}: desired_healthy={}, disruptions_allowed={}",
@@ -257,8 +271,16 @@ impl<S: Storage + 'static> PodDisruptionBudgetController<S> {
                     }
                 }
             };
-            // desired_healthy = total - max_unavailable
-            Ok(total_pods - max_unavailable_count)
+            // desired_healthy = total - max_unavailable, floored at 0.
+            // maxUnavailable may legitimately exceed the pod count — it means
+            // every pod is disposable — and a count of pods cannot be negative.
+            //
+            // K8s ref: pkg/controller/disruption/disruption.go:
+            //   desiredHealthy = expectedCount - int32(maxUnavailable)
+            //   if desiredHealthy < 0 {
+            //       desiredHealthy = 0
+            //   }
+            Ok((total_pods - max_unavailable_count).max(0))
         } else {
             // No min_available or max_unavailable specified - invalid PDB
             Err(rusternetes_common::Error::InvalidResource(
@@ -379,6 +401,36 @@ mod tests {
         let pdb = PodDisruptionBudget::new("test-pdb", "default", spec);
         let desired = controller.calculate_desired_healthy(&pdb, 5).unwrap();
         assert_eq!(desired, 3); // 5 - 2 = 3
+    }
+
+    #[tokio::test]
+    async fn test_calculate_desired_healthy_max_unavailable_exceeding_pod_count() {
+        let storage = Arc::new(MemoryStorage::new());
+        let controller = PodDisruptionBudgetController::new(storage);
+
+        // maxUnavailable above the pod count means every pod is disposable, so
+        // the number that must stay healthy is 0 — never a negative count.
+        for (max_unavailable, total_pods) in [(5, 3), (1, 0), (100, 1)] {
+            let spec = PodDisruptionBudgetSpec {
+                min_available: None,
+                max_unavailable: Some(IntOrString::Int(max_unavailable)),
+                selector: LabelSelector {
+                    match_labels: Some(HashMap::new()),
+                    match_expressions: None,
+                },
+                unhealthy_pod_eviction_policy: None,
+            };
+
+            let pdb = PodDisruptionBudget::new("test-pdb", "default", spec);
+            let desired = controller
+                .calculate_desired_healthy(&pdb, total_pods)
+                .unwrap();
+
+            assert_eq!(
+                desired, 0,
+                "maxUnavailable={max_unavailable} over {total_pods} pods"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/controller-manager/tests/pdb_controller_test.rs
+++ b/crates/controller-manager/tests/pdb_controller_test.rs
@@ -557,3 +557,134 @@ async fn test_pdb_only_counts_healthy_pods() {
         "At minimum healthy threshold"
     );
 }
+
+#[tokio::test]
+async fn test_pdb_disruptions_allowed_is_never_negative_when_budget_is_breached() {
+    let storage = setup_test().await;
+    let controller = PodDisruptionBudgetController::new(storage.clone());
+
+    // minAvailable=3 over 3 pods, but only 1 of them is healthy: the budget is
+    // already breached, so no disruption is allowed. It is not "-2 allowed".
+    let spec = PodDisruptionBudgetSpec {
+        min_available: Some(IntOrString::Int(3)),
+        max_unavailable: None,
+        selector: LabelSelector {
+            match_labels: Some(HashMap::from([("app".to_string(), "web".to_string())])),
+            match_expressions: None,
+        },
+        unhealthy_pod_eviction_policy: None,
+    };
+
+    let pdb = PodDisruptionBudget::new("web-pdb", "default", spec);
+    let pdb_key = build_key("poddisruptionbudgets", Some("default"), "web-pdb");
+    storage.create(&pdb_key, &pdb).await.unwrap();
+
+    for i in 0..3 {
+        let pod = create_test_pod(
+            &format!("web-{}", i),
+            "default",
+            HashMap::from([("app".to_string(), "web".to_string())]),
+            i == 0,
+        );
+        let pod_key = build_key("pods", Some("default"), &format!("web-{}", i));
+        storage.create(&pod_key, &pod).await.unwrap();
+    }
+
+    controller.reconcile_all().await.unwrap();
+
+    let status = storage
+        .get::<PodDisruptionBudget>(&pdb_key)
+        .await
+        .unwrap()
+        .status
+        .expect("Status should be set");
+
+    assert_eq!(status.current_healthy, 1);
+    assert_eq!(status.desired_healthy, 3);
+    assert_eq!(status.expected_pods, 3);
+    assert_eq!(
+        status.disruptions_allowed, 0,
+        "a breached budget allows no disruptions, not a negative number of them"
+    );
+}
+
+#[tokio::test]
+async fn test_pdb_desired_healthy_is_never_negative_when_max_unavailable_exceeds_pods() {
+    let storage = setup_test().await;
+    let controller = PodDisruptionBudgetController::new(storage.clone());
+
+    // maxUnavailable=5 over 3 pods is legal — it means every pod is disposable.
+    let spec = PodDisruptionBudgetSpec {
+        min_available: None,
+        max_unavailable: Some(IntOrString::Int(5)),
+        selector: LabelSelector {
+            match_labels: Some(HashMap::from([("app".to_string(), "batch".to_string())])),
+            match_expressions: None,
+        },
+        unhealthy_pod_eviction_policy: None,
+    };
+
+    let pdb = PodDisruptionBudget::new("batch-pdb", "default", spec);
+    let pdb_key = build_key("poddisruptionbudgets", Some("default"), "batch-pdb");
+    storage.create(&pdb_key, &pdb).await.unwrap();
+
+    for i in 0..3 {
+        let pod = create_test_pod(
+            &format!("batch-{}", i),
+            "default",
+            HashMap::from([("app".to_string(), "batch".to_string())]),
+            true,
+        );
+        let pod_key = build_key("pods", Some("default"), &format!("batch-{}", i));
+        storage.create(&pod_key, &pod).await.unwrap();
+    }
+
+    controller.reconcile_all().await.unwrap();
+
+    let status = storage
+        .get::<PodDisruptionBudget>(&pdb_key)
+        .await
+        .unwrap()
+        .status
+        .expect("Status should be set");
+
+    assert_eq!(
+        status.desired_healthy, 0,
+        "3 - maxUnavailable(5) floors at 0"
+    );
+    assert_eq!(status.current_healthy, 3);
+    assert_eq!(status.disruptions_allowed, 3, "all three pods may go");
+}
+
+#[tokio::test]
+async fn test_pdb_with_no_matching_pods_allows_no_disruptions() {
+    let storage = setup_test().await;
+    let controller = PodDisruptionBudgetController::new(storage.clone());
+
+    let spec = PodDisruptionBudgetSpec {
+        min_available: Some(IntOrString::Int(2)),
+        max_unavailable: None,
+        selector: LabelSelector {
+            match_labels: Some(HashMap::from([("app".to_string(), "absent".to_string())])),
+            match_expressions: None,
+        },
+        unhealthy_pod_eviction_policy: None,
+    };
+
+    let pdb = PodDisruptionBudget::new("absent-pdb", "default", spec);
+    let pdb_key = build_key("poddisruptionbudgets", Some("default"), "absent-pdb");
+    storage.create(&pdb_key, &pdb).await.unwrap();
+
+    controller.reconcile_all().await.unwrap();
+
+    let status = storage
+        .get::<PodDisruptionBudget>(&pdb_key)
+        .await
+        .unwrap()
+        .status
+        .expect("Status should be set");
+
+    assert_eq!(status.expected_pods, 0);
+    assert_eq!(status.current_healthy, 0);
+    assert_eq!(status.disruptions_allowed, 0);
+}


### PR DESCRIPTION
## Summary

Fixes #102. `reconcile_pdb` published two PDB status counts without clamping them:

```rust
// pod_disruption_budget.rs:175
let disruptions_allowed = healthy_pods - desired_healthy;

// :261, in the maxUnavailable branch of calculate_desired_healthy
Ok(total_pods - max_unavailable_count)
```

Both are counts of pods, and both went negative on ordinary input. Driving
`reconcile_all` against `MemoryStorage`:

| PDB spec | matching pods | published `desiredHealthy` | published `disruptionsAllowed` |
| --- | --- | --- | --- |
| `minAvailable: 3` | 3, of which 1 healthy | 3 | **-2** |
| `maxUnavailable: 5` | 3, all healthy | **-2** | 5 |
| `minAvailable: 2` | none | 2 | **-2** |

The first row is the common case — any workload degraded below its budget reported
a negative number of allowed disruptions. The second needs no unusual spec either:
`maxUnavailable` above the pod count is legal and means every pod is disposable.

`disruptionsAllowed` is what users see as ALLOWED DISRUPTIONS, and it is read as a
count elsewhere in this tree. `pod_subresources.rs:1125` denies eviction on any
value `<= 0` and `:1135` re-clamps with `.max(0)` before quoting it, so the
defensive handling already existed at the consumer while the controller kept
publishing values that needed it. Nothing here validates the sign or magnitude of
`minAvailable` / `maxUnavailable`, so the status cannot rely on the spec.

## Change

Clamp both, matching the two guards in
`pkg/controller/disruption/disruption.go`:

```go
desiredHealthy = expectedCount - int32(maxUnavailable)
if desiredHealthy < 0 { desiredHealthy = 0 }

disruptionsAllowed := currentHealthy - desiredHealthy
if expectedCount <= 0 || disruptionsAllowed <= 0 { disruptionsAllowed = 0 }
```

The `expectedCount <= 0` half is carried over as an explicit `total_pods <= 0`
arm rather than folded into the `max(0)`: it is what keeps a PDB whose selector
matches nothing reporting 0, even if `minAvailable` is negative — which nothing
rejects.

The `minAvailable` branch is otherwise unchanged. It returns the requested count
directly, as upstream does, and a `minAvailable` above the pod count is meaningful
— it makes disruption impossible rather than negative.

## Validation

No cluster and no container runtime — plain `cargo test`.

Four tests added: one unit test over the `maxUnavailable` branch of
`calculate_desired_healthy`, three integration tests over the published status.

| test | before | after |
| --- | --- | --- |
| `test_calculate_desired_healthy_max_unavailable_exceeding_pod_count` | **fails** | passes |
| `test_pdb_disruptions_allowed_is_never_negative_when_budget_is_breached` | **fails** | passes |
| `test_pdb_desired_healthy_is_never_negative_when_max_unavailable_exceeds_pods` | **fails** | passes |
| `test_pdb_with_no_matching_pods_allows_no_disruptions` | **fails** | passes |
| the other 13 PDB unit + integration tests | passes | passes |

Reverting only the two production hunks with the tests in place fails exactly
those four:

```
---- test_pdb_disruptions_allowed_is_never_negative_when_budget_is_breached ----
assertion `left == right` failed: a breached budget allows no disruptions, not a
negative number of them
  left: -2
 right: 0

---- test_pdb_desired_healthy_is_never_negative_when_max_unavailable_exceeds_pods ----
assertion `left == right` failed: 3 - maxUnavailable(5) floors at 0
  left: -2
 right: 0
```

- `cargo test --workspace --locked`: **140 suites, 4236 tests, 0 failed**
- `cargo fmt` (workspace members, as the fmt workflow runs it): clean
- `cargo clippy --workspace --all-targets --locked`: no warnings in
  `crates/controller-manager/src/controllers/pod_disruption_budget.rs` or
  `crates/controller-manager/tests/pdb_controller_test.rs`

## Not addressed

`maxUnavailable` percentages resolve with `floor` (`:251`) while `minAvailable`
uses `ceil` (`:228`); upstream's disruption controller passes `roundUp=true` for
both. A percentage `maxUnavailable` therefore keeps one more pod healthy than
upstream would — stricter rather than unsafe. It is a separate behaviour change,
noted on the issue.
