### PR TITLE
fix(controller-manager): renumber CronJob day-of-week for the cron crate

### DIFF
--- a/crates/controller-manager/src/controllers/cronjob.rs
+++ b/crates/controller-manager/src/controllers/cronjob.rs
@@ -8,6 +8,79 @@ use std::time::Duration;
 use tokio::time;
 use tracing::{debug, error, info, warn};
 
+/// Renumber a day-of-week field from Kubernetes' numbering to the `cron` crate's.
+///
+/// Kubernetes follows standard cron and numbers days 0-6 with Sunday as 0. The
+/// `cron` crate numbers them 1-7 with Sunday as 1, so every day value has to be
+/// shifted up by one.
+///
+/// Only value positions are shifted. A step (`*/2`) counts intervals rather than
+/// days, and day names (`SUN`, `MON`) already mean the same thing to both, so
+/// both are passed through untouched — as is any number outside 0-6, which lets
+/// the parser reject it rather than turning it into a different day.
+fn renumber_day_of_week(field: &str) -> String {
+    field
+        .split(',')
+        .map(|item| {
+            let (values, step) = match item.split_once('/') {
+                Some((values, step)) => (values, Some(step)),
+                None => (item, None),
+            };
+
+            let renumbered = values
+                .split('-')
+                .map(|value| match value.parse::<u32>() {
+                    Ok(day) if day <= 6 => (day + 1).to_string(),
+                    _ => value.to_string(),
+                })
+                .collect::<Vec<_>>()
+                .join("-");
+
+            match step {
+                Some(step) => format!("{}/{}", renumbered, step),
+                None => renumbered,
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+/// Convert a Kubernetes cron schedule into the expression the `cron` crate parses.
+///
+/// Kubernetes accepts the standard five-field form (`min hour dom month dow`)
+/// plus the `@` shortcuts. The crate wants seven (`sec min hour dom month dow
+/// year`) and numbers days of the week differently, so the day-of-week field is
+/// renumbered as well as padded.
+fn to_cron_expression(schedule: &str) -> String {
+    let expanded = match schedule.trim() {
+        "@yearly" | "@annually" => "0 0 1 1 *",
+        "@monthly" => "0 0 1 * *",
+        "@weekly" => "0 0 * * 0",
+        "@daily" | "@midnight" => "0 0 * * *",
+        "@hourly" => "0 * * * *",
+        other => other,
+    };
+
+    // Kubernetes supports `?` in cron expressions (Quartz-style "no specific
+    // value"). Replace with `*` since the `cron` crate doesn't support `?`.
+    let expanded = expanded.replace('?', "*");
+
+    let mut fields: Vec<String> = expanded.split_whitespace().map(str::to_string).collect();
+
+    // Five and six fields are the Kubernetes-shaped forms, where day of week is
+    // the fifth field. A seven-field expression is already in the crate's own
+    // format and is left alone.
+    if matches!(fields.len(), 5 | 6) {
+        fields[4] = renumber_day_of_week(&fields[4]);
+    }
+
+    match fields.len() {
+        5 => format!("0 {} *", fields.join(" ")),
+        6 => format!("0 {}", fields.join(" ")),
+        _ => fields.join(" "),
+    }
+}
+
 pub struct CronJobController<S: Storage> {
     storage: Arc<S>,
 }
@@ -347,31 +420,7 @@ impl<S: Storage + 'static> CronJobController<S> {
         // Get last schedule time
         let last_schedule = cronjob.status.as_ref().and_then(|s| s.last_schedule_time);
 
-        // Handle special schedules (Kubernetes 5-field format)
-        let cron_schedule = match schedule {
-            "@yearly" | "@annually" => "0 0 1 1 *",
-            "@monthly" => "0 0 1 * *",
-            "@weekly" => "0 0 * * 0",
-            "@daily" | "@midnight" => "0 0 * * *",
-            "@hourly" => "0 * * * *",
-            other => other,
-        };
-
-        // Kubernetes supports `?` in cron expressions (Quartz-style "no specific value").
-        // Replace with `*` since the `cron` crate doesn't support `?`.
-        let cron_schedule = cron_schedule.replace('?', "*");
-
-        // The `cron` crate expects 7 fields (sec min hour dom month dow year),
-        // but Kubernetes uses 5 fields (min hour dom month dow).
-        // Convert by prepending "0" for seconds and appending "*" for year.
-        let field_count = cron_schedule.split_whitespace().count();
-        let cron_schedule = if field_count == 5 {
-            format!("0 {} *", cron_schedule)
-        } else if field_count == 6 {
-            format!("0 {}", cron_schedule)
-        } else {
-            cron_schedule.to_string()
-        };
+        let cron_schedule = to_cron_expression(schedule);
 
         // Parse cron expression using the `cron` crate
         let schedule_parsed = match cron::Schedule::try_from(cron_schedule.as_str()) {
@@ -569,12 +618,92 @@ impl<S: Storage + 'static> CronJobController<S> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use chrono::{Datelike, TimeZone, Utc, Weekday};
+
+    /// The weekday a schedule actually fires on, as the controller parses it.
+    fn first_fire_weekday(schedule: &str) -> Weekday {
+        let expression = to_cron_expression(schedule);
+        let parsed = cron::Schedule::try_from(expression.as_str())
+            .unwrap_or_else(|e| panic!("{schedule:?} -> {expression:?} did not parse: {e}"));
+
+        // Saturday 2026-08-01, so the following week covers every weekday.
+        let after = Utc.with_ymd_and_hms(2026, 8, 1, 0, 0, 0).unwrap();
+        parsed
+            .after(&after)
+            .next()
+            .unwrap_or_else(|| panic!("{schedule:?} has no next fire time"))
+            .weekday()
+    }
+
     #[test]
-    fn test_cron_schedule_parsing() {
-        // Test that schedule patterns are recognized
-        assert!("*/5 * * * *".starts_with("*/"));
-        assert_eq!("@hourly", "@hourly");
-        assert_eq!("@daily", "@daily");
+    fn test_day_of_week_numbers_follow_kubernetes() {
+        // Kubernetes numbers days 0-6 with Sunday as 0.
+        let expected = [
+            ("0", Weekday::Sun),
+            ("1", Weekday::Mon),
+            ("2", Weekday::Tue),
+            ("3", Weekday::Wed),
+            ("4", Weekday::Thu),
+            ("5", Weekday::Fri),
+            ("6", Weekday::Sat),
+        ];
+
+        for (day, weekday) in expected {
+            assert_eq!(
+                first_fire_weekday(&format!("0 0 * * {day}")),
+                weekday,
+                "day-of-week {day}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_day_of_week_names_are_unchanged() {
+        // Names already mean the same thing to both, so they must not shift.
+        assert_eq!(first_fire_weekday("0 0 * * SUN"), Weekday::Sun);
+        assert_eq!(first_fire_weekday("0 0 * * MON"), Weekday::Mon);
+        assert_eq!(first_fire_weekday("0 0 * * SAT"), Weekday::Sat);
+    }
+
+    #[test]
+    fn test_weekly_shortcut_runs_on_sunday() {
+        // "@weekly" expands to day-of-week 0, which the crate rejects untranslated.
+        assert_eq!(first_fire_weekday("@weekly"), Weekday::Sun);
+    }
+
+    #[test]
+    fn test_day_of_week_lists_ranges_and_steps() {
+        // Lists and ranges shift; the step interval does not.
+        assert_eq!(renumber_day_of_week("0"), "1");
+        assert_eq!(renumber_day_of_week("0,3"), "1,4");
+        assert_eq!(renumber_day_of_week("1-5"), "2-6");
+        assert_eq!(renumber_day_of_week("1-5/2"), "2-6/2");
+        assert_eq!(renumber_day_of_week("*/2"), "*/2");
+        assert_eq!(renumber_day_of_week("*"), "*");
+        assert_eq!(renumber_day_of_week("MON-FRI"), "MON-FRI");
+
+        // A Monday-to-Friday range must still be Monday to Friday.
+        assert_eq!(first_fire_weekday("0 0 * * 1-5"), Weekday::Mon);
+        // 0,3 is Sunday and Wednesday; Sunday comes first after a Saturday.
+        assert_eq!(first_fire_weekday("0 0 * * 0,3"), Weekday::Sun);
+    }
+
+    #[test]
+    fn test_non_weekday_fields_are_untouched() {
+        assert_eq!(to_cron_expression("*/5 * * * *"), "0 */5 * * * * *");
+        assert_eq!(to_cron_expression("@hourly"), "0 0 * * * * *");
+        assert_eq!(to_cron_expression("@daily"), "0 0 0 * * * *");
+        assert_eq!(to_cron_expression("@monthly"), "0 0 0 1 * * *");
+        assert_eq!(to_cron_expression("@yearly"), "0 0 0 1 1 * *");
+        // `?` is accepted by Kubernetes but not by the crate.
+        assert_eq!(to_cron_expression("0 0 ? * *"), "0 0 0 * * * *");
+        // A seven-field expression is already in the crate's format.
+        assert_eq!(
+            to_cron_expression("0 0 0 * * 1 *"),
+            "0 0 0 * * 1 *",
+            "seven-field expressions must not be renumbered twice"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #110. `should_run_now` padded a Kubernetes schedule out to the seven fields
the `cron` crate wants, but the two number days of the week differently:

- Kubernetes, following standard cron: **0-6, Sunday = 0**
- `cron` 0.17: **1-7, Sunday = 1**

Nothing renumbered the field, so every numeric day was read as the day before the
one requested, and `0` was out of range entirely. Feeding the expressions the
controller built straight to `cron::Schedule`, searching forward from Saturday
2026-08-01:

| schedule | expression built | first fire | intended |
| --- | --- | --- | --- |
| `0 0 * * 0` | `0 0 0 * * 0 *` | **parse error** | Sunday |
| `@weekly` | `0 0 0 * * 0 *` | **parse error** | Sunday |
| `0 0 * * 1` | `0 0 0 * * 1 *` | Sun 2026-08-02 | Monday |
| `0 0 * * 6` | `0 0 0 * * 6 *` | Fri 2026-08-07 | Saturday |
| `0 0 * * SUN` | `0 0 0 * * SUN *` | Sun 2026-08-02 | Sunday |

`@weekly` is caught by this because it expands to `0 0 * * 0` at `cronjob.rs:354`,
which is the one value the crate rejects. Day names are unaffected — both
numberings agree on those.

The failure is silent. A parse error is swallowed at `cronjob.rs:379-382` into a
warning and `Ok(false)`, and `status.lastScheduleTime` is only written on the
job-creation path (`:396`), so an affected CronJob reports nothing and keeps an
empty `lastScheduleTime` forever.

## Change

Renumber the day-of-week field before handing the expression to the crate. Only
value positions shift:

| input | output | why |
| --- | --- | --- |
| `0` | `1` | Sunday in both numberings |
| `0,3` | `1,4` | each list entry is a day |
| `1-5` | `2-6` | both range endpoints are days |
| `1-5/2` | `2-6/2` | the step counts intervals, not days |
| `*/2` | `*/2` | no day values to shift |
| `MON-FRI` | `MON-FRI` | names already agree |
| `9` | `9` | left for the parser to reject |

The conversion moves out of `should_run_now` into `to_cron_expression`, a free
function, so the mapping is testable without a controller or storage. Seven-field
input is left alone: it is already in the crate's own format, and renumbering it
would shift a day that was never in Kubernetes numbering.

## Validation

No cluster and no container runtime — plain `cargo test`.

`test_cron_schedule_parsing` asserted string literals
(`assert_eq!("@hourly", "@hourly")`) and exercised neither the conversion nor the
parse, which is why none of this was visible. It is replaced by five tests that
assert the weekday a schedule actually fires on:

| test | before | after |
| --- | --- | --- |
| `test_day_of_week_numbers_follow_kubernetes` (all seven days) | **fails** | passes |
| `test_weekly_shortcut_runs_on_sunday` | **fails** | passes |
| `test_day_of_week_lists_ranges_and_steps` | **fails** | passes |
| `test_day_of_week_names_are_unchanged` | passes | passes |
| `test_non_weekday_fields_are_untouched` | passes | passes |

Reverting only the renumbering with the tests in place fails exactly those three
and leaves the name and non-weekday tests passing, which is what shows the change
is confined to numeric day-of-week values:

```
"@weekly" -> "0 0 0 * * 0 *" did not parse: 0 0 0 * * 0 *
"0 0 * * 0" -> "0 0 0 * * 0 *" did not parse: 0 0 0 * * 0 *
assertion `left == right` failed
  left: Sun
 right: Mon
```

- `cargo test --workspace --locked`: **140 suites, 4250 tests, 0 failed**
- `cargo fmt` (workspace members, as the fmt workflow runs it): clean
- `cargo clippy --workspace --all-targets --locked`: no warnings in
  `crates/controller-manager/src/controllers/cronjob.rs`
